### PR TITLE
Borrow strings from input for &str and Cow<str>

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -130,7 +130,13 @@ pub trait Format {
     ///
     /// `string_offsets` provides the discovered `(ptr, len, cap)` field offsets
     /// within String's memory layout, enabling direct writes.
-    fn emit_read_string(&self, ectx: &mut EmitCtx, offset: usize, string_offsets: &StringOffsets);
+    fn emit_read_string(
+        &self,
+        ectx: &mut EmitCtx,
+        offset: usize,
+        scalar_type: ScalarType,
+        string_offsets: &StringOffsets,
+    );
 
     /// Emit code to deserialize an enum value.
     ///


### PR DESCRIPTION
## Summary
Implement zero-copy string deserialization from input buffers for borrowed targets.

## Changes
- Add string-kind-aware emission for `String`, `&str`, and `Cow<str>`
- Postcard: support zero-copy `&str` and borrowed `Cow<str>`
- JSON: support zero-copy `&str` fast path, and `Cow<str>` with borrowed fast path + owned escape slow path
- Update solver string classification to include `Str` and `CowStr`
- Tie `deserialize` output lifetime to input with `deserialize<'input, T: Facet<'input>>`
- Add regression tests for postcard and JSON borrowed/owned string behavior

## Test Plan
- cargo check
- cargo nextest run

Fixes #27
