### PR TITLE
Support u128/i128/usize/isize/char scalars in JSON and postcard

### DIFF
--- a/src/json.rs
+++ b/src/json.rs
@@ -504,13 +504,18 @@ impl Format for FadJson {
             ScalarType::U16 => json_intrinsics::fad_json_read_u16 as _,
             ScalarType::U32 => json_intrinsics::fad_json_read_u32 as _,
             ScalarType::U64 => json_intrinsics::fad_json_read_u64 as _,
+            ScalarType::U128 => json_intrinsics::fad_json_read_u128 as _,
+            ScalarType::USize => json_intrinsics::fad_json_read_usize as _,
             ScalarType::I8 => json_intrinsics::fad_json_read_i8 as _,
             ScalarType::I16 => json_intrinsics::fad_json_read_i16 as _,
             ScalarType::I32 => json_intrinsics::fad_json_read_i32 as _,
             ScalarType::I64 => json_intrinsics::fad_json_read_i64 as _,
+            ScalarType::I128 => json_intrinsics::fad_json_read_i128 as _,
+            ScalarType::ISize => json_intrinsics::fad_json_read_isize as _,
             ScalarType::F32 => json_intrinsics::fad_json_read_f32 as _,
             ScalarType::F64 => unreachable!(),
             ScalarType::Bool => json_intrinsics::fad_json_read_bool as _,
+            ScalarType::Char => json_intrinsics::fad_json_read_char as _,
             _ => panic!("unsupported JSON scalar: {:?}", scalar_type),
         };
         ectx.emit_call_intrinsic(fn_ptr, offset as u32);
@@ -951,16 +956,21 @@ impl Format for FadJson {
                         }
                         _ => match inner_shape.scalar_type() {
                             Some(ScalarType::String) => string_variants.push(i),
+                            Some(ScalarType::Char) => string_variants.push(i),
                             Some(ScalarType::Bool) => bool_variants.push(i),
                             Some(
                                 ScalarType::U8
                                 | ScalarType::U16
                                 | ScalarType::U32
                                 | ScalarType::U64
+                                | ScalarType::U128
+                                | ScalarType::USize
                                 | ScalarType::I8
                                 | ScalarType::I16
                                 | ScalarType::I32
                                 | ScalarType::I64
+                                | ScalarType::I128
+                                | ScalarType::ISize
                                 | ScalarType::F32
                                 | ScalarType::F64,
                             ) => number_variants.push(i),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,12 +158,17 @@ mod tests {
         a_u16: u16,
         a_u32: u32,
         a_u64: u64,
+        a_u128: u128,
+        a_usize: usize,
         a_i8: i8,
         a_i16: i16,
         a_i32: i32,
         a_i64: i64,
+        a_i128: i128,
+        a_isize: isize,
         a_f32: f32,
         a_f64: f64,
+        a_char: char,
         a_name: String,
     }
 
@@ -181,12 +186,17 @@ mod tests {
             a_u16: u16,
             a_u32: u32,
             a_u64: u64,
+            a_u128: u128,
+            a_usize: usize,
             a_i8: i8,
             a_i16: i16,
             a_i32: i32,
             a_i64: i64,
+            a_i128: i128,
+            a_isize: isize,
             a_f32: f32,
             a_f64: f64,
+            a_char: char,
             a_name: String,
         }
 
@@ -196,12 +206,17 @@ mod tests {
             a_u16: 1000,
             a_u32: 70000,
             a_u64: 1_000_000_000_000,
+            a_u128: 18_446_744_073_709_551_621u128,
+            a_usize: 12345,
             a_i8: -42,
             a_i16: -1000,
             a_i32: -70000,
             a_i64: -1_000_000_000_000,
+            a_i128: -18_446_744_073_709_551_621i128,
+            a_isize: -12345,
             a_f32: 3.14,
             a_f64: 2.718281828459045,
+            a_char: 'ß',
             a_name: "hello".into(),
         };
 
@@ -214,12 +229,17 @@ mod tests {
         assert_eq!(result.a_u16, 1000);
         assert_eq!(result.a_u32, 70000);
         assert_eq!(result.a_u64, 1_000_000_000_000);
+        assert_eq!(result.a_u128, 18_446_744_073_709_551_621u128);
+        assert_eq!(result.a_usize, 12345);
         assert_eq!(result.a_i8, -42);
         assert_eq!(result.a_i16, -1000);
         assert_eq!(result.a_i32, -70000);
         assert_eq!(result.a_i64, -1_000_000_000_000);
+        assert_eq!(result.a_i128, -18_446_744_073_709_551_621i128);
+        assert_eq!(result.a_isize, -12345);
         assert_eq!(result.a_f32, 3.14);
         assert_eq!(result.a_f64, 2.718281828459045);
+        assert_eq!(result.a_char, 'ß');
         assert_eq!(result.a_name, "hello");
     }
 
@@ -234,12 +254,17 @@ mod tests {
             "a_u16": 1000,
             "a_u32": 70000,
             "a_u64": 1000000000000,
+            "a_u128": 18446744073709551621,
+            "a_usize": 12345,
             "a_i8": -42,
             "a_i16": -1000,
             "a_i32": -70000,
             "a_i64": -1000000000000,
+            "a_i128": -18446744073709551621,
+            "a_isize": -12345,
             "a_f32": 3.14,
             "a_f64": 2.718281828459045,
+            "a_char": "\u00df",
             "a_name": "hello"
         }"#;
 
@@ -251,12 +276,17 @@ mod tests {
         assert_eq!(result.a_u16, 1000);
         assert_eq!(result.a_u32, 70000);
         assert_eq!(result.a_u64, 1_000_000_000_000);
+        assert_eq!(result.a_u128, 18_446_744_073_709_551_621u128);
+        assert_eq!(result.a_usize, 12345);
         assert_eq!(result.a_i8, -42);
         assert_eq!(result.a_i16, -1000);
         assert_eq!(result.a_i32, -70000);
         assert_eq!(result.a_i64, -1_000_000_000_000);
+        assert_eq!(result.a_i128, -18_446_744_073_709_551_621i128);
+        assert_eq!(result.a_isize, -12345);
         assert_eq!(result.a_f32, 3.14);
         assert_eq!(result.a_f64, 2.718281828459045);
+        assert_eq!(result.a_char, 'ß');
         assert_eq!(result.a_name, "hello");
     }
 

--- a/src/postcard.rs
+++ b/src/postcard.rs
@@ -67,6 +67,11 @@ impl Format for FadPostcard {
             ScalarType::I64 => ectx.emit_inline_varint_fast_path(
                 offset, 8, true, intrinsics::fad_read_i64 as _,
             ),
+            ScalarType::U128 => ectx.emit_call_intrinsic(intrinsics::fad_read_u128 as _, offset),
+            ScalarType::I128 => ectx.emit_call_intrinsic(intrinsics::fad_read_i128 as _, offset),
+            ScalarType::USize => ectx.emit_call_intrinsic(intrinsics::fad_read_usize as _, offset),
+            ScalarType::ISize => ectx.emit_call_intrinsic(intrinsics::fad_read_isize as _, offset),
+            ScalarType::Char => ectx.emit_call_intrinsic(intrinsics::fad_read_char as _, offset),
             _ => panic!("unsupported postcard scalar: {:?}", scalar_type),
         }
     }
@@ -212,6 +217,8 @@ impl Format for FadPostcard {
                 ScalarType::I16 => Some((2, true, intrinsics::fad_read_i16 as *const u8)),
                 ScalarType::I32 => Some((4, true, intrinsics::fad_read_i32 as *const u8)),
                 ScalarType::I64 => Some((8, true, intrinsics::fad_read_i64 as *const u8)),
+                ScalarType::USize => Some((core::mem::size_of::<usize>() as u32, false, intrinsics::fad_read_usize as *const u8)),
+                ScalarType::ISize => Some((core::mem::size_of::<isize>() as u32, true, intrinsics::fad_read_isize as *const u8)),
                 _ => None,
             }
         });

--- a/src/solver.rs
+++ b/src/solver.rs
@@ -26,7 +26,7 @@ impl JsonValueType {
             Type::User(UserType::Struct(_)) => JsonValueType::Object,
             Type::User(UserType::Enum(_)) => JsonValueType::Object,
             _ => match shape.scalar_type() {
-                Some(ScalarType::String) => JsonValueType::String,
+                Some(ScalarType::String | ScalarType::Char) => JsonValueType::String,
                 Some(ScalarType::Bool) => JsonValueType::Bool,
                 Some(
                     ScalarType::U8


### PR DESCRIPTION
## Summary
Adds support for the remaining scalar types that previously panicked at runtime: `u128`, `i128`, `usize`, `isize`, and `char`.

## Changes
- Wire JSON scalar dispatch and add new JSON intrinsics for `u128`, `i128`, `usize`, `isize`, and `char`
- Wire postcard scalar dispatch and add postcard intrinsics for `u128`, `i128`, `usize`, `isize`, and `char`
- Extend untagged JSON enum value-type classification to handle these scalar types (`char` as string; new integer types as numbers)
- Expand scalar regression tests to include all newly supported types for both JSON and postcard

## Testing
- `cargo check`
- `cargo nextest run postcard_all_scalars json_all_scalars`
- `cargo nextest run`

Fixes #24
