### PR TITLE
Add text-format parsers for RVSDG IR and RA-MIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +37,15 @@ name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "ar_archive_writer"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+dependencies = [
+ "object",
+]
 
 [[package]]
 name = "atomic-polyfill"
@@ -99,10 +117,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cc"
+version = "1.2.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chumsky"
+version = "1.0.0-alpha.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e82d74e6c83060ec269fe9e0d408d6de4a1645d525f9a0bbbb841ba4efd91ac"
+dependencies = [
+ "hashbrown 0.15.5",
+ "regex-automata",
+ "serde",
+ "stacker",
+ "unicode-ident",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cobs"
@@ -267,6 +309,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -318,6 +366,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -410,6 +460,7 @@ name = "kajit"
 version = "0.1.0"
 dependencies = [
  "brotli",
+ "chumsky",
  "dynasm",
  "dynasmrt",
  "facet",
@@ -495,6 +546,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -555,6 +615,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+dependencies = [
+ "ar_archive_writer",
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,6 +658,23 @@ dependencies = [
  "rustc-hash",
  "smallvec",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rustc-hash"
@@ -673,6 +760,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,6 +791,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stacker"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "strsim"
@@ -760,6 +866,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ dynasm = "5"
 itoa = "1"
 zmij = "1"
 regalloc2 = "0.15"
+chumsky = "1.0.0-alpha.8"
 
 [dev-dependencies]
 postcard = { version = "1", features = ["alloc"] }

--- a/src/intrinsics.rs
+++ b/src/intrinsics.rs
@@ -1153,3 +1153,117 @@ pub unsafe extern "C" fn kajit_encode_char(ctx: *mut EncodeContext, field_ptr: *
     unsafe { core::ptr::copy_nonoverlapping(buf.as_ptr(), ctx.output_ptr, len) };
     ctx.output_ptr = unsafe { ctx.output_ptr.add(len) };
 }
+
+/// Returns all known postcard intrinsics as `(name, IntrinsicFn)` pairs.
+pub fn known_intrinsics() -> Vec<(&'static str, crate::ir::IntrinsicFn)> {
+    use crate::ir::IntrinsicFn;
+    vec![
+        ("kajit_read_bool", IntrinsicFn(kajit_read_bool as *const () as usize)),
+        ("kajit_read_u8", IntrinsicFn(kajit_read_u8 as *const () as usize)),
+        ("kajit_read_u16", IntrinsicFn(kajit_read_u16 as *const () as usize)),
+        (
+            "kajit_read_varint_u32",
+            IntrinsicFn(kajit_read_varint_u32 as *const () as usize),
+        ),
+        ("kajit_read_u64", IntrinsicFn(kajit_read_u64 as *const () as usize)),
+        ("kajit_read_u128", IntrinsicFn(kajit_read_u128 as *const () as usize)),
+        ("kajit_read_usize", IntrinsicFn(kajit_read_usize as *const () as usize)),
+        ("kajit_read_i8", IntrinsicFn(kajit_read_i8 as *const () as usize)),
+        ("kajit_read_i16", IntrinsicFn(kajit_read_i16 as *const () as usize)),
+        ("kajit_read_i32", IntrinsicFn(kajit_read_i32 as *const () as usize)),
+        ("kajit_read_i64", IntrinsicFn(kajit_read_i64 as *const () as usize)),
+        ("kajit_read_i128", IntrinsicFn(kajit_read_i128 as *const () as usize)),
+        ("kajit_read_isize", IntrinsicFn(kajit_read_isize as *const () as usize)),
+        ("kajit_read_f32", IntrinsicFn(kajit_read_f32 as *const () as usize)),
+        ("kajit_read_f64", IntrinsicFn(kajit_read_f64 as *const () as usize)),
+        ("kajit_read_char", IntrinsicFn(kajit_read_char as *const () as usize)),
+        (
+            "kajit_read_postcard_string",
+            IntrinsicFn(kajit_read_postcard_string as *const () as usize),
+        ),
+        (
+            "kajit_read_postcard_string_with_len",
+            IntrinsicFn(kajit_read_postcard_string_with_len as *const () as usize),
+        ),
+        (
+            "kajit_read_postcard_str",
+            IntrinsicFn(kajit_read_postcard_str as *const () as usize),
+        ),
+        (
+            "kajit_read_postcard_str_with_len",
+            IntrinsicFn(kajit_read_postcard_str_with_len as *const () as usize),
+        ),
+        (
+            "kajit_read_postcard_cow_str",
+            IntrinsicFn(kajit_read_postcard_cow_str as *const () as usize),
+        ),
+        (
+            "kajit_read_postcard_cow_str_with_len",
+            IntrinsicFn(kajit_read_postcard_cow_str_with_len as *const () as usize),
+        ),
+        (
+            "kajit_option_init_none",
+            IntrinsicFn(kajit_option_init_none as *const () as usize),
+        ),
+        (
+            "kajit_option_init_some",
+            IntrinsicFn(kajit_option_init_some as *const () as usize),
+        ),
+        (
+            "kajit_option_init_none_ctx",
+            IntrinsicFn(kajit_option_init_none_ctx as *const () as usize),
+        ),
+        (
+            "kajit_option_init_some_ctx",
+            IntrinsicFn(kajit_option_init_some_ctx as *const () as usize),
+        ),
+        (
+            "kajit_pointer_new_into",
+            IntrinsicFn(kajit_pointer_new_into as *const () as usize),
+        ),
+        (
+            "kajit_postcard_validate_and_alloc_string",
+            IntrinsicFn(kajit_postcard_validate_and_alloc_string as *const () as usize),
+        ),
+        (
+            "kajit_string_validate_alloc_copy",
+            IntrinsicFn(kajit_string_validate_alloc_copy as *const () as usize),
+        ),
+        ("kajit_vec_alloc", IntrinsicFn(kajit_vec_alloc as *const () as usize)),
+        ("kajit_vec_grow", IntrinsicFn(kajit_vec_grow as *const () as usize)),
+        ("kajit_vec_free", IntrinsicFn(kajit_vec_free as *const () as usize)),
+        (
+            "kajit_field_default_trait",
+            IntrinsicFn(kajit_field_default_trait as *const () as usize),
+        ),
+        (
+            "kajit_field_default_custom",
+            IntrinsicFn(kajit_field_default_custom as *const () as usize),
+        ),
+        (
+            "kajit_field_default_indirect",
+            IntrinsicFn(kajit_field_default_indirect as *const () as usize),
+        ),
+        ("kajit_map_build", IntrinsicFn(kajit_map_build as *const () as usize)),
+        (
+            "kajit_output_grow",
+            IntrinsicFn(kajit_output_grow as *const () as usize),
+        ),
+        (
+            "kajit_encode_postcard_string",
+            IntrinsicFn(kajit_encode_postcard_string as *const () as usize),
+        ),
+        (
+            "kajit_encode_u128",
+            IntrinsicFn(kajit_encode_u128 as *const () as usize),
+        ),
+        (
+            "kajit_encode_i128",
+            IntrinsicFn(kajit_encode_i128 as *const () as usize),
+        ),
+        (
+            "kajit_encode_char",
+            IntrinsicFn(kajit_encode_char as *const () as usize),
+        ),
+    ]
+}

--- a/src/ir_parse.rs
+++ b/src/ir_parse.rs
@@ -1,0 +1,1392 @@
+//! RVSDG textual parser for kajit IR.
+//!
+//! Parses the text format produced by `IrFunc::Display` (with registry) back into
+//! an `IrFunc`. Two passes: parse text → AST, then resolve references → IrFunc.
+
+use std::collections::HashMap;
+
+use chumsky::prelude::*;
+
+use crate::context::ErrorCode;
+use crate::ir::{
+    Arena, IntrinsicFn, IntrinsicRegistry, InputPort, IrFunc, IrOp, LambdaId, Node, NodeId,
+    NodeKind, OutputPort, OutputRef, PortKind, PortSource, Region, RegionArg, RegionArgRef,
+    RegionId, RegionResult, SlotId, VReg, Width,
+};
+
+// ─── AST types (first pass) ────────────────────────────────────────────────
+
+/// A parsed source reference (unresolved).
+#[derive(Debug, Clone)]
+enum AstSource {
+    /// `v0`, `v42` — data value from a node output
+    VReg(u32),
+    /// `%cs:n5` — cursor state from node n5's output
+    CursorNode(u32),
+    /// `%os:n3` — output state from node n3's output
+    OutputNode(u32),
+    /// `%cs:arg` — cursor state from region argument
+    CursorArg,
+    /// `%os:arg` — output state from region argument
+    OutputArg,
+    /// `arg0`, `arg1` — data value from region argument
+    RegionArg(u16),
+    /// `n1.2` — node output by index (fallback when no vreg)
+    NodeOutput(u32, u16),
+}
+
+/// A parsed output port (unresolved).
+#[derive(Debug, Clone)]
+enum AstOutput {
+    /// `v0` — data output with vreg
+    VReg(u32),
+    /// `%cs` — cursor state output
+    Cursor,
+    /// `%os` — output state output
+    Output,
+    /// `?` — data output without vreg assignment
+    Unknown,
+}
+
+/// A parsed node (unresolved).
+#[derive(Debug, Clone)]
+enum AstNode {
+    Simple {
+        id: u32,
+        op: AstOp,
+        inputs: Vec<AstSource>,
+        outputs: Vec<AstOutput>,
+    },
+    Gamma {
+        id: u32,
+        pred: AstSource,
+        extra_inputs: Vec<AstSource>,
+        branches: Vec<AstRegion>,
+        outputs: Vec<AstOutput>,
+    },
+    Theta {
+        id: u32,
+        inputs: Vec<AstSource>,
+        body: AstRegion,
+        outputs: Vec<AstOutput>,
+    },
+    Apply {
+        id: u32,
+        target: u32,
+        inputs: Vec<AstSource>,
+        outputs: Vec<AstOutput>,
+    },
+}
+
+/// A parsed region (unresolved).
+#[derive(Debug, Clone)]
+struct AstRegion {
+    args: Vec<AstRegionArg>,
+    nodes: Vec<AstNode>,
+    results: Vec<AstSource>,
+}
+
+#[derive(Debug, Clone)]
+enum AstRegionArg {
+    Data(u16),   // arg0, arg1, ...
+    Cursor,      // %cs
+    Output,      // %os
+}
+
+/// A parsed lambda (unresolved).
+#[derive(Debug, Clone)]
+struct AstLambda {
+    id: u32,
+    #[allow(dead_code)]
+    shape: String,
+    body: AstRegion,
+}
+
+// ─── Parsers ────────────────────────────────────────────────────────────────
+
+type Extra<'src> = extra::Err<Rich<'src, char>>;
+
+fn ws<'src>() -> impl Parser<'src, &'src str, (), Extra<'src>> + Clone {
+    any()
+        .filter(|c: &char| c.is_whitespace())
+        .repeated()
+        .ignored()
+}
+
+/// Parse a u32 decimal number.
+fn uint32<'src>() -> impl Parser<'src, &'src str, u32, Extra<'src>> + Clone {
+    text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u32>().unwrap())
+}
+
+/// Parse a u64 number (decimal or hex with 0x prefix).
+fn uint64<'src>() -> impl Parser<'src, &'src str, u64, Extra<'src>> + Clone {
+    let hex = just("0x")
+        .ignore_then(text::int::<_, Extra<'_>>(16))
+        .map(|s: &str| u64::from_str_radix(s, 16).unwrap());
+    let dec = text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u64>().unwrap());
+    hex.or(dec)
+}
+
+/// Parse a u16 decimal number.
+fn uint16<'src>() -> impl Parser<'src, &'src str, u16, Extra<'src>> + Clone {
+    text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u16>().unwrap())
+}
+
+/// Parse a width: W1, W2, W4, W8.
+fn width<'src>() -> impl Parser<'src, &'src str, Width, Extra<'src>> + Clone {
+    choice((
+        just("W1").to(Width::W1),
+        just("W2").to(Width::W2),
+        just("W4").to(Width::W4),
+        just("W8").to(Width::W8),
+    ))
+}
+
+/// Parse an ErrorCode name.
+fn error_code<'src>() -> impl Parser<'src, &'src str, ErrorCode, Extra<'src>> + Clone {
+    choice((
+        just("UnexpectedEof").to(ErrorCode::UnexpectedEof),
+        just("InvalidVarint").to(ErrorCode::InvalidVarint),
+        just("InvalidUtf8").to(ErrorCode::InvalidUtf8),
+        just("UnsupportedShape").to(ErrorCode::UnsupportedShape),
+        just("ExpectedObjectStart").to(ErrorCode::ExpectedObjectStart),
+        just("ExpectedColon").to(ErrorCode::ExpectedColon),
+        just("ExpectedStringKey").to(ErrorCode::ExpectedStringKey),
+        just("UnterminatedString").to(ErrorCode::UnterminatedString),
+        just("InvalidJsonNumber").to(ErrorCode::InvalidJsonNumber),
+        just("MissingRequiredField").to(ErrorCode::MissingRequiredField),
+        just("UnexpectedCharacter").to(ErrorCode::UnexpectedCharacter),
+        just("NumberOutOfRange").to(ErrorCode::NumberOutOfRange),
+        just("InvalidBool").to(ErrorCode::InvalidBool),
+        just("UnknownVariant").to(ErrorCode::UnknownVariant),
+        just("ExpectedTagKey").to(ErrorCode::ExpectedTagKey),
+        just("AmbiguousVariant").to(ErrorCode::AmbiguousVariant),
+        just("AllocError").to(ErrorCode::AllocError),
+        just("InvalidEscapeSequence").to(ErrorCode::InvalidEscapeSequence),
+        just("UnknownField").to(ErrorCode::UnknownField),
+    ))
+}
+
+/// Parse a source reference.
+fn source<'src>() -> impl Parser<'src, &'src str, AstSource, Extra<'src>> + Clone {
+    // Order matters: try more specific patterns first
+    let cursor_node = just("%cs:n").ignore_then(uint32()).map(AstSource::CursorNode);
+    let output_node = just("%os:n").ignore_then(uint32()).map(AstSource::OutputNode);
+    let cursor_arg = just("%cs:arg").to(AstSource::CursorArg);
+    let output_arg = just("%os:arg").to(AstSource::OutputArg);
+    let region_arg = just("arg").ignore_then(uint16()).map(AstSource::RegionArg);
+    let node_output = just("n")
+        .ignore_then(uint32())
+        .then_ignore(just("."))
+        .then(uint16())
+        .map(|(n, i)| AstSource::NodeOutput(n, i));
+    let vreg = just("v").ignore_then(uint32()).map(AstSource::VReg);
+
+    choice((
+        cursor_arg,
+        output_arg,
+        cursor_node,
+        output_node,
+        region_arg,
+        node_output,
+        vreg,
+    ))
+}
+
+/// Parse an output port.
+fn output<'src>() -> impl Parser<'src, &'src str, AstOutput, Extra<'src>> + Clone {
+    let cursor = just("%cs").to(AstOutput::Cursor);
+    let output_state = just("%os").to(AstOutput::Output);
+    let unknown = just("?").to(AstOutput::Unknown);
+    let vreg = just("v").ignore_then(uint32()).map(AstOutput::VReg);
+
+    choice((cursor, output_state, unknown, vreg))
+}
+
+/// Parse a comma-separated list inside brackets.
+fn bracketed_list<'src, T: 'src>(
+    inner: impl Parser<'src, &'src str, T, Extra<'src>> + Clone,
+) -> impl Parser<'src, &'src str, Vec<T>, Extra<'src>> + Clone {
+    inner
+        .separated_by(just(",").padded_by(ws()))
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(just("[").then(ws()), ws().then(just("]")))
+}
+
+/// Parse an intrinsic function reference: `@name` or hex `0xABC`.
+fn intrinsic_ref<'src>() -> impl Parser<'src, &'src str, IntrinsicRef, Extra<'src>> + Clone {
+    let named = just("@").ignore_then(
+        any()
+            .filter(|c: &char| c.is_alphanumeric() || *c == '_')
+            .repeated()
+            .at_least(1)
+            .to_slice()
+            .map(|s: &str| IntrinsicRef::Named(s.to_string())),
+    );
+    let hex = just("0x")
+        .ignore_then(text::int::<_, Extra<'_>>(16))
+        .map(|s: &str| IntrinsicRef::Address(usize::from_str_radix(s, 16).unwrap()));
+    named.or(hex)
+}
+
+#[derive(Debug, Clone)]
+enum IntrinsicRef {
+    Named(String),
+    Address(usize),
+}
+
+/// Parse an IrOp (the operation name with parameters).
+fn ir_op<'src>() -> impl Parser<'src, &'src str, AstOp, Extra<'src>> + Clone {
+    let cursor_ops = choice((
+        just("ReadBytes(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(|c| AstOp::Resolved(IrOp::ReadBytes { count: c })),
+        just("PeekByte").to(AstOp::Resolved(IrOp::PeekByte)),
+        just("AdvanceCursorBy").to(AstOp::Resolved(IrOp::AdvanceCursorBy)),
+        just("AdvanceCursor(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(|c| AstOp::Resolved(IrOp::AdvanceCursor { count: c })),
+        just("BoundsCheck(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(|c| AstOp::Resolved(IrOp::BoundsCheck { count: c })),
+        just("SaveCursor").to(AstOp::Resolved(IrOp::SaveCursor)),
+        just("RestoreCursor").to(AstOp::Resolved(IrOp::RestoreCursor)),
+    ));
+
+    let output_ops = choice((
+        just("WriteToField(offset=")
+            .ignore_then(uint32())
+            .then_ignore(just(",").then(ws()))
+            .then(width())
+            .then_ignore(just(")"))
+            .map(|(o, w)| AstOp::Resolved(IrOp::WriteToField { offset: o, width: w })),
+        just("ReadFromField(offset=")
+            .ignore_then(uint32())
+            .then_ignore(just(",").then(ws()))
+            .then(width())
+            .then_ignore(just(")"))
+            .map(|(o, w)| AstOp::Resolved(IrOp::ReadFromField { offset: o, width: w })),
+        just("SaveOutPtr").to(AstOp::Resolved(IrOp::SaveOutPtr)),
+        just("SetOutPtr").to(AstOp::Resolved(IrOp::SetOutPtr)),
+    ));
+
+    let stack_ops = choice((
+        just("SlotAddr(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(|s| AstOp::Resolved(IrOp::SlotAddr { slot: SlotId::new(s) })),
+        just("WriteToSlot(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(|s| AstOp::Resolved(IrOp::WriteToSlot { slot: SlotId::new(s) })),
+        just("ReadFromSlot(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(|s| AstOp::Resolved(IrOp::ReadFromSlot { slot: SlotId::new(s) })),
+    ));
+
+    let arith_ops = choice((
+        just("Const(")
+            .ignore_then(uint64())
+            .then_ignore(just(")"))
+            .map(|v| AstOp::Resolved(IrOp::Const { value: v })),
+        just("CmpNe").to(AstOp::Resolved(IrOp::CmpNe)),
+        just("Add").to(AstOp::Resolved(IrOp::Add)),
+        just("Sub").to(AstOp::Resolved(IrOp::Sub)),
+        just("And").to(AstOp::Resolved(IrOp::And)),
+        just("Or").to(AstOp::Resolved(IrOp::Or)),
+        just("Shr").to(AstOp::Resolved(IrOp::Shr)),
+        just("Shl").to(AstOp::Resolved(IrOp::Shl)),
+        just("Xor").to(AstOp::Resolved(IrOp::Xor)),
+        just("ZigzagDecode(wide=")
+            .ignore_then(choice((just("true").to(true), just("false").to(false))))
+            .then_ignore(just(")"))
+            .map(|w| AstOp::Resolved(IrOp::ZigzagDecode { wide: w })),
+        just("SignExtend(from=")
+            .ignore_then(width())
+            .then_ignore(just(")"))
+            .map(|w| AstOp::Resolved(IrOp::SignExtend { from_width: w })),
+    ));
+
+    let call_ops = choice((
+        just("CallIntrinsic(")
+            .ignore_then(intrinsic_ref())
+            .then_ignore(just(",").then(ws()).then(just("field_offset=")))
+            .then(uint32())
+            .then_ignore(just(")"))
+            .map(|(func, fo)| AstOp::CallIntrinsic { func, field_offset: fo }),
+        just("CallPure(")
+            .ignore_then(intrinsic_ref())
+            .then_ignore(just(")"))
+            .map(|func| AstOp::CallPure { func }),
+        just("ErrorExit(")
+            .ignore_then(error_code())
+            .then_ignore(just(")"))
+            .map(|c| AstOp::Resolved(IrOp::ErrorExit { code: c })),
+        just("SimdStringScan").to(AstOp::Resolved(IrOp::SimdStringScan)),
+        just("SimdWhitespaceSkip").to(AstOp::Resolved(IrOp::SimdWhitespaceSkip)),
+    ));
+
+    choice((cursor_ops, output_ops, stack_ops, arith_ops, call_ops))
+}
+
+/// AST op — some ops are fully resolved, some need intrinsic lookup.
+#[derive(Debug, Clone)]
+enum AstOp {
+    Resolved(IrOp),
+    CallIntrinsic {
+        func: IntrinsicRef,
+        field_offset: u32,
+    },
+    CallPure {
+        func: IntrinsicRef,
+    },
+}
+
+/// Parse a region arg: `%cs`, `%os`, `arg0`, `arg1`, etc.
+fn region_arg<'src>() -> impl Parser<'src, &'src str, AstRegionArg, Extra<'src>> + Clone {
+    let cursor = just("%cs").to(AstRegionArg::Cursor);
+    let output_state = just("%os").to(AstRegionArg::Output);
+    let data = just("arg").ignore_then(uint16()).map(AstRegionArg::Data);
+    choice((cursor, output_state, data))
+}
+
+fn region<'src>() -> impl Parser<'src, &'src str, AstRegion, Extra<'src>> + Clone {
+    recursive(|region| {
+        let args = just("args:")
+            .padded_by(ws())
+            .ignore_then(bracketed_list(region_arg()));
+
+        let simple_node = just("n")
+            .ignore_then(uint32())
+            .then_ignore(ws().then(just("=")).then(ws()))
+            .then(ir_op())
+            .then_ignore(ws())
+            .then(bracketed_list(source()))
+            .then_ignore(ws().then(just("->")).then(ws()))
+            .then(bracketed_list(output()))
+            .map(|(((id, op), inputs), outputs)| AstNode::Simple {
+                id,
+                op,
+                inputs,
+                outputs,
+            });
+
+        let gamma_node = just("n")
+            .ignore_then(uint32())
+            .then_ignore(ws().then(just("=")).then(ws()).then(just("gamma")).then(ws()))
+            .then_ignore(just("[").then(ws()))
+            .then(
+                // pred: <source>
+                just("pred:")
+                    .padded_by(ws())
+                    .ignore_then(source())
+                    .then_ignore(ws()),
+            )
+            .then(
+                // in0: <source>, in1: <source>, ...
+                just("in")
+                    .ignore_then(uint32())
+                    .ignore_then(just(":").then(ws()))
+                    .ignore_then(source())
+                    .then_ignore(ws())
+                    .repeated()
+                    .collect::<Vec<_>>(),
+            )
+            .then_ignore(ws().then(just("]")).then(ws()).then(just("{")).then(ws()))
+            .then(
+                // branches
+                just("branch")
+                    .padded_by(ws())
+                    .ignore_then(uint32())
+                    .then_ignore(just(":").then(ws()))
+                    .ignore_then(
+                        just("region")
+                            .ignore_then(ws())
+                            .ignore_then(just("{"))
+                            .ignore_then(ws())
+                            .ignore_then(region.clone())
+                            .then_ignore(ws().then(just("}")).then(ws())),
+                    )
+                    .repeated()
+                    .at_least(1)
+                    .collect::<Vec<_>>(),
+            )
+            .then_ignore(ws().then(just("}")).then(ws()).then(just("->")).then(ws()))
+            .then(bracketed_list(output()))
+            .map(
+                |((((id, pred), extra_inputs), branches), outputs)| AstNode::Gamma {
+                    id,
+                    pred,
+                    extra_inputs,
+                    branches,
+                    outputs,
+                },
+            );
+
+        let theta_node = just("n")
+            .ignore_then(uint32())
+            .then_ignore(ws().then(just("=")).then(ws()).then(just("theta")).then(ws()))
+            .then(bracketed_list(source()))
+            .then_ignore(ws().then(just("{")).then(ws()))
+            .then(
+                just("region")
+                    .ignore_then(ws())
+                    .ignore_then(just("{"))
+                    .ignore_then(ws())
+                    .ignore_then(region.clone())
+                    .then_ignore(ws().then(just("}"))),
+            )
+            .then_ignore(ws().then(just("}")).then(ws()).then(just("->")).then(ws()))
+            .then(bracketed_list(output()))
+            .map(|(((id, inputs), body), outputs)| AstNode::Theta {
+                id,
+                inputs,
+                body,
+                outputs,
+            });
+
+        let apply_node = just("n")
+            .ignore_then(uint32())
+            .then_ignore(ws().then(just("=")).then(ws()).then(just("apply")).then(ws()))
+            .then_ignore(just("@"))
+            .then(uint32())
+            .then_ignore(ws())
+            .then(bracketed_list(source()))
+            .then_ignore(ws().then(just("->")).then(ws()))
+            .then(bracketed_list(output()))
+            .map(|(((id, target), inputs), outputs)| AstNode::Apply {
+                id,
+                target,
+                inputs,
+                outputs,
+            });
+
+        let node = choice((gamma_node, theta_node, apply_node, simple_node));
+
+        let nodes = node.padded_by(ws()).repeated().collect::<Vec<_>>();
+
+        let results = just("results:")
+            .padded_by(ws())
+            .ignore_then(bracketed_list(source()));
+
+        args.then_ignore(ws())
+            .then(nodes)
+            .then_ignore(ws())
+            .then(results)
+            .map(|((args, nodes), results)| AstRegion {
+                args,
+                nodes,
+                results,
+            })
+    })
+}
+
+fn lambda<'src>() -> impl Parser<'src, &'src str, AstLambda, Extra<'src>> + Clone {
+    just("lambda")
+        .padded_by(ws())
+        .ignore_then(just("@"))
+        .ignore_then(uint32())
+        .then_ignore(ws())
+        .then(
+            just("(shape:")
+                .ignore_then(ws())
+                .ignore_then(
+                    just("\"")
+                        .ignore_then(any().filter(|c: &char| *c != '"').repeated().to_slice())
+                        .then_ignore(just("\"")),
+                )
+                .then_ignore(just(")")),
+        )
+        .then_ignore(ws().then(just("{")).then(ws()))
+        .then(
+            just("region")
+                .ignore_then(ws())
+                .ignore_then(just("{"))
+                .ignore_then(ws())
+                .ignore_then(region())
+                .then_ignore(ws().then(just("}"))),
+        )
+        .then_ignore(ws().then(just("}")))
+        .map(|((id, shape), body)| AstLambda {
+            id,
+            shape: shape.to_string(),
+            body,
+        })
+}
+
+fn program<'src>() -> impl Parser<'src, &'src str, Vec<AstLambda>, Extra<'src>> + Clone {
+    lambda()
+        .padded_by(ws())
+        .repeated()
+        .at_least(1)
+        .collect::<Vec<_>>()
+        .then_ignore(end())
+}
+
+// ─── Resolution (second pass) ──────────────────────────────────────────────
+
+/// Parse error with context.
+#[derive(Debug)]
+pub struct ParseError {
+    pub message: String,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse an RVSDG text format into an `IrFunc`.
+///
+/// The `shape` parameter provides the `&'static Shape` for the root lambda.
+/// For test fixtures, use `<u8 as facet::Facet>::SHAPE` as a dummy.
+///
+/// The `registry` resolves `@name` intrinsic references to `IntrinsicFn` values.
+pub fn parse_ir(
+    input: &str,
+    shape: &'static facet::Shape,
+    registry: &IntrinsicRegistry,
+) -> Result<IrFunc, ParseError> {
+    let result = program().parse(input);
+
+    let lambdas = result.into_result().map_err(|errs| {
+        let msgs: Vec<String> = errs
+            .into_iter()
+            .map(|e| format!("{e}"))
+            .collect();
+        ParseError {
+            message: msgs.join("\n"),
+        }
+    })?;
+
+    resolve(lambdas, shape, registry)
+}
+
+/// Resolve AST references into a concrete `IrFunc`.
+fn resolve(
+    lambdas: Vec<AstLambda>,
+    shape: &'static facet::Shape,
+    registry: &IntrinsicRegistry,
+) -> Result<IrFunc, ParseError> {
+    let mut func = IrFunc {
+        nodes: Arena::new(),
+        regions: Arena::new(),
+        root: NodeId::new(0),
+        vreg_count: 0,
+        slot_count: 0,
+        lambdas: Vec::new(),
+    };
+
+    // Track max vreg and slot seen, to set counts at the end.
+    let mut max_vreg: u32 = 0;
+    let mut max_slot: u32 = 0;
+
+    // We need to process lambdas in order. The first lambda is the root.
+    // We'll do a two-pass approach:
+    // 1. Pre-allocate all lambdas (so cross-references work).
+    // 2. Build the body regions.
+
+    // Mapping from AST node id → actual NodeId (within each region context).
+    // Since node IDs in the text format are globally unique per lambda, we
+    // build a global mapping.
+    let mut node_map: HashMap<u32, NodeId> = HashMap::new();
+
+    // Pre-allocate lambda nodes in the arena first (so they get low indices
+    // matching the original IrBuilder pattern: lambda@0 → NodeId 0, etc.).
+    let sentinel_region = RegionId::new(u32::MAX);
+    let placeholder_body = RegionId::new(u32::MAX);
+    let mut lambda_node_ids = Vec::new();
+    for ast_lambda in &lambdas {
+        let lambda_id = LambdaId::new(ast_lambda.id);
+        let lambda_shape = shape; // non-root lambdas also get same shape for now
+        let node_id = func.nodes.push(Node {
+            region: sentinel_region,
+            inputs: Vec::new(),
+            outputs: Vec::new(),
+            kind: NodeKind::Lambda {
+                body: placeholder_body,
+                shape: lambda_shape,
+                lambda_id,
+            },
+        });
+        lambda_node_ids.push((ast_lambda.id, node_id, lambda_id));
+
+        while func.lambdas.len() <= lambda_id.index() {
+            func.lambdas.push(NodeId::new(u32::MAX));
+        }
+        func.lambdas[lambda_id.index()] = node_id;
+        if ast_lambda.id == 0 {
+            func.root = node_id;
+        }
+    }
+
+    // Now build the body regions for each lambda and patch the lambda nodes.
+    for (i, ast_lambda) in lambdas.iter().enumerate() {
+        let (_, node_id, lambda_id) = lambda_node_ids[i];
+
+        let body_region_id = resolve_region(
+            &ast_lambda.body,
+            &mut func,
+            &mut node_map,
+            &mut max_vreg,
+            &mut max_slot,
+            registry,
+        )?;
+
+        // Patch the lambda node's body region.
+        func.nodes[node_id].kind = NodeKind::Lambda {
+            body: body_region_id,
+            shape,
+            lambda_id,
+        };
+    }
+
+    func.vreg_count = if max_vreg == 0 && node_map.is_empty() {
+        0
+    } else {
+        max_vreg + 1
+    };
+    func.slot_count = max_slot + 1;
+
+    Ok(func)
+}
+
+fn resolve_region(
+    ast: &AstRegion,
+    func: &mut IrFunc,
+    node_map: &mut HashMap<u32, NodeId>,
+    max_vreg: &mut u32,
+    max_slot: &mut u32,
+    registry: &IntrinsicRegistry,
+) -> Result<RegionId, ParseError> {
+    // Build region args.
+    let args: Vec<RegionArg> = ast
+        .args
+        .iter()
+        .map(|a| match a {
+            AstRegionArg::Data(idx) => {
+                let _ = idx;
+                RegionArg {
+                    kind: PortKind::Data,
+                    vreg: None,
+                }
+            }
+            AstRegionArg::Cursor => RegionArg {
+                kind: PortKind::StateCursor,
+                vreg: None,
+            },
+            AstRegionArg::Output => RegionArg {
+                kind: PortKind::StateOutput,
+                vreg: None,
+            },
+        })
+        .collect();
+
+    let region_id = func.regions.push(Region {
+        args,
+        results: Vec::new(),
+        nodes: Vec::new(),
+    });
+
+    // First pass: create placeholder nodes so we can resolve forward references.
+    // Actually, the text format lists nodes in order, and sources always reference
+    // earlier nodes or region args. So we can build them sequentially.
+    for ast_node in &ast.nodes {
+        let node_id = resolve_node(ast_node, region_id, func, node_map, max_vreg, max_slot, registry)?;
+        func.regions[region_id].nodes.push(node_id);
+    }
+
+    // Resolve results.
+    let results: Vec<RegionResult> = ast
+        .results
+        .iter()
+        .map(|s| {
+            let (source, kind) = resolve_source(s, region_id, node_map, func);
+            RegionResult { kind, source }
+        })
+        .collect();
+    func.regions[region_id].results = results;
+
+    Ok(region_id)
+}
+
+fn resolve_node(
+    ast: &AstNode,
+    region_id: RegionId,
+    func: &mut IrFunc,
+    node_map: &mut HashMap<u32, NodeId>,
+    max_vreg: &mut u32,
+    max_slot: &mut u32,
+    registry: &IntrinsicRegistry,
+) -> Result<NodeId, ParseError> {
+    match ast {
+        AstNode::Simple {
+            id,
+            op,
+            inputs,
+            outputs,
+        } => {
+            let resolved_op = resolve_op(op, registry)?;
+
+            // Track slots.
+            match &resolved_op {
+                IrOp::SlotAddr { slot }
+                | IrOp::WriteToSlot { slot }
+                | IrOp::ReadFromSlot { slot } => {
+                    *max_slot = (*max_slot).max(slot.index() as u32);
+                }
+                _ => {}
+            }
+
+            let resolved_inputs: Vec<InputPort> = inputs
+                .iter()
+                .map(|s| {
+                    let (source, kind) = resolve_source(s, region_id, node_map, func);
+                    InputPort { kind, source }
+                })
+                .collect();
+
+            let resolved_outputs: Vec<OutputPort> = outputs
+                .iter()
+                .map(|o| resolve_output(o, max_vreg))
+                .collect();
+
+            // Patch CallIntrinsic/CallPure arg_count and has_result from actual ports.
+            let resolved_op = match resolved_op {
+                IrOp::CallIntrinsic {
+                    func: f,
+                    field_offset,
+                    ..
+                } => {
+                    let data_inputs = resolved_inputs
+                        .iter()
+                        .filter(|i| i.kind == PortKind::Data)
+                        .count();
+                    let has_result = resolved_outputs
+                        .iter()
+                        .any(|o| o.kind == PortKind::Data);
+                    IrOp::CallIntrinsic {
+                        func: f,
+                        arg_count: data_inputs as u8,
+                        has_result,
+                        field_offset,
+                    }
+                }
+                IrOp::CallPure { func: f, .. } => {
+                    let arg_count = resolved_inputs.len();
+                    IrOp::CallPure {
+                        func: f,
+                        arg_count: arg_count as u8,
+                    }
+                }
+                other => other,
+            };
+
+            let node_id = func.nodes.push(Node {
+                region: region_id,
+                inputs: resolved_inputs,
+                outputs: resolved_outputs,
+                kind: NodeKind::Simple(resolved_op),
+            });
+
+            node_map.insert(*id, node_id);
+            Ok(node_id)
+        }
+
+        AstNode::Gamma {
+            id,
+            pred,
+            extra_inputs,
+            branches,
+            outputs,
+        } => {
+            // Build sub-regions first.
+            let mut region_ids = Vec::new();
+            for branch in branches {
+                let rid = resolve_region(branch, func, node_map, max_vreg, max_slot, registry)?;
+                region_ids.push(rid);
+            }
+
+            // Build inputs: pred + extra + cursor + output state
+            let mut resolved_inputs = Vec::new();
+            let (pred_source, pred_kind) = resolve_source(pred, region_id, node_map, func);
+            resolved_inputs.push(InputPort {
+                kind: pred_kind,
+                source: pred_source,
+            });
+            for s in extra_inputs {
+                let (source, kind) = resolve_source(s, region_id, node_map, func);
+                resolved_inputs.push(InputPort { kind, source });
+            }
+
+            let resolved_outputs: Vec<OutputPort> = outputs
+                .iter()
+                .map(|o| resolve_output(o, max_vreg))
+                .collect();
+
+            let node_id = func.nodes.push(Node {
+                region: region_id,
+                inputs: resolved_inputs,
+                outputs: resolved_outputs,
+                kind: NodeKind::Gamma {
+                    regions: region_ids,
+                },
+            });
+
+            node_map.insert(*id, node_id);
+            Ok(node_id)
+        }
+
+        AstNode::Theta {
+            id,
+            inputs,
+            body,
+            outputs,
+        } => {
+            let body_id = resolve_region(body, func, node_map, max_vreg, max_slot, registry)?;
+
+            let resolved_inputs: Vec<InputPort> = inputs
+                .iter()
+                .map(|s| {
+                    let (source, kind) = resolve_source(s, region_id, node_map, func);
+                    InputPort { kind, source }
+                })
+                .collect();
+
+            let resolved_outputs: Vec<OutputPort> = outputs
+                .iter()
+                .map(|o| resolve_output(o, max_vreg))
+                .collect();
+
+            let node_id = func.nodes.push(Node {
+                region: region_id,
+                inputs: resolved_inputs,
+                outputs: resolved_outputs,
+                kind: NodeKind::Theta { body: body_id },
+            });
+
+            node_map.insert(*id, node_id);
+            Ok(node_id)
+        }
+
+        AstNode::Apply {
+            id,
+            target,
+            inputs,
+            outputs,
+        } => {
+            let resolved_inputs: Vec<InputPort> = inputs
+                .iter()
+                .map(|s| {
+                    let (source, kind) = resolve_source(s, region_id, node_map, func);
+                    InputPort { kind, source }
+                })
+                .collect();
+
+            let resolved_outputs: Vec<OutputPort> = outputs
+                .iter()
+                .map(|o| resolve_output(o, max_vreg))
+                .collect();
+
+            let node_id = func.nodes.push(Node {
+                region: region_id,
+                inputs: resolved_inputs,
+                outputs: resolved_outputs,
+                kind: NodeKind::Apply {
+                    target: LambdaId::new(*target),
+                },
+            });
+
+            node_map.insert(*id, node_id);
+            Ok(node_id)
+        }
+    }
+}
+
+fn resolve_source(
+    s: &AstSource,
+    region_id: RegionId,
+    node_map: &HashMap<u32, NodeId>,
+    func: &IrFunc,
+) -> (PortSource, PortKind) {
+    match s {
+        AstSource::VReg(v) => {
+            // Find which node output has this vreg. We need to search for it.
+            // Look through all known nodes.
+            for (_, &node_id) in node_map {
+                let node = &func.nodes[node_id];
+                for (idx, out) in node.outputs.iter().enumerate() {
+                    if out.kind == PortKind::Data {
+                        if let Some(vreg) = out.vreg {
+                            if vreg.index() == *v as usize {
+                                return (
+                                    PortSource::Node(OutputRef {
+                                        node: node_id,
+                                        index: idx as u16,
+                                    }),
+                                    PortKind::Data,
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            // Fallback: might be referencing a region arg with a vreg.
+            // This shouldn't happen in our format, but panic clearly.
+            panic!("unresolved vreg v{v}");
+        }
+        AstSource::CursorNode(n) => {
+            let node_id = node_map[n];
+            let node = &func.nodes[node_id];
+            for (idx, out) in node.outputs.iter().enumerate() {
+                if out.kind == PortKind::StateCursor {
+                    return (
+                        PortSource::Node(OutputRef {
+                            node: node_id,
+                            index: idx as u16,
+                        }),
+                        PortKind::StateCursor,
+                    );
+                }
+            }
+            panic!("no cursor state output on node n{n}");
+        }
+        AstSource::OutputNode(n) => {
+            let node_id = node_map[n];
+            let node = &func.nodes[node_id];
+            for (idx, out) in node.outputs.iter().enumerate() {
+                if out.kind == PortKind::StateOutput {
+                    return (
+                        PortSource::Node(OutputRef {
+                            node: node_id,
+                            index: idx as u16,
+                        }),
+                        PortKind::StateOutput,
+                    );
+                }
+            }
+            panic!("no output state output on node n{n}");
+        }
+        AstSource::CursorArg => {
+            let region = &func.regions[region_id];
+            for (idx, arg) in region.args.iter().enumerate() {
+                if arg.kind == PortKind::StateCursor {
+                    return (
+                        PortSource::RegionArg(RegionArgRef {
+                            region: region_id,
+                            index: idx as u16,
+                        }),
+                        PortKind::StateCursor,
+                    );
+                }
+            }
+            panic!("no cursor state arg in region");
+        }
+        AstSource::OutputArg => {
+            let region = &func.regions[region_id];
+            for (idx, arg) in region.args.iter().enumerate() {
+                if arg.kind == PortKind::StateOutput {
+                    return (
+                        PortSource::RegionArg(RegionArgRef {
+                            region: region_id,
+                            index: idx as u16,
+                        }),
+                        PortKind::StateOutput,
+                    );
+                }
+            }
+            panic!("no output state arg in region");
+        }
+        AstSource::RegionArg(idx) => (
+            PortSource::RegionArg(RegionArgRef {
+                region: region_id,
+                index: *idx,
+            }),
+            PortKind::Data,
+        ),
+        AstSource::NodeOutput(n, idx) => {
+            let node_id = node_map[n];
+            let node = &func.nodes[node_id];
+            let kind = node.outputs[*idx as usize].kind;
+            (
+                PortSource::Node(OutputRef {
+                    node: node_id,
+                    index: *idx,
+                }),
+                kind,
+            )
+        }
+    }
+}
+
+fn resolve_output(o: &AstOutput, max_vreg: &mut u32) -> OutputPort {
+    match o {
+        AstOutput::VReg(v) => {
+            *max_vreg = (*max_vreg).max(*v);
+            OutputPort {
+                kind: PortKind::Data,
+                vreg: Some(VReg::new(*v)),
+            }
+        }
+        AstOutput::Cursor => OutputPort {
+            kind: PortKind::StateCursor,
+            vreg: None,
+        },
+        AstOutput::Output => OutputPort {
+            kind: PortKind::StateOutput,
+            vreg: None,
+        },
+        AstOutput::Unknown => OutputPort {
+            kind: PortKind::Data,
+            vreg: None,
+        },
+    }
+}
+
+fn resolve_op(op: &AstOp, registry: &IntrinsicRegistry) -> Result<IrOp, ParseError> {
+    match op {
+        AstOp::Resolved(ir_op) => Ok(ir_op.clone()),
+        AstOp::CallIntrinsic { func, field_offset } => {
+            let intrinsic = resolve_intrinsic(func, registry)?;
+            // Count args from the inputs (they'll be resolved separately).
+            // For now, arg_count and has_result are inferred from the node's
+            // input/output ports during resolve_node. But IrOp needs them.
+            // We'll set them to 0/false here and patch them in resolve_node.
+            Ok(IrOp::CallIntrinsic {
+                func: intrinsic,
+                arg_count: 0,    // patched later from actual inputs
+                has_result: false, // patched later from actual outputs
+                field_offset: *field_offset,
+            })
+        }
+        AstOp::CallPure { func } => {
+            let intrinsic = resolve_intrinsic(func, registry)?;
+            Ok(IrOp::CallPure {
+                func: intrinsic,
+                arg_count: 0, // patched later
+            })
+        }
+    }
+}
+
+fn resolve_intrinsic(
+    r: &IntrinsicRef,
+    registry: &IntrinsicRegistry,
+) -> Result<IntrinsicFn, ParseError> {
+    match r {
+        IntrinsicRef::Named(name) => registry.func_by_name(name).ok_or_else(|| ParseError {
+            message: format!("unknown intrinsic: @{name}"),
+        }),
+        IntrinsicRef::Address(addr) => Ok(IntrinsicFn(*addr)),
+    }
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{IrBuilder, Width};
+
+    fn test_shape() -> &'static facet::Shape {
+        <u8 as facet::Facet>::SHAPE
+    }
+
+    #[test]
+    fn parse_simple_read_write() {
+        let input = r#"
+lambda @0 (shape: "u8") {
+  region {
+    args: [%cs, %os]
+    n0 = BoundsCheck(4) [%cs:arg] -> [%cs]
+    n1 = ReadBytes(4) [%cs:n0] -> [v0, %cs]
+    n2 = WriteToField(offset=0, W4) [v0, %os:arg] -> [%os]
+    results: [%cs:n1, %os:n2]
+  }
+}
+"#;
+
+        let registry = IntrinsicRegistry::empty();
+        let func = parse_ir(input, test_shape(), &registry).unwrap();
+
+        // Verify structure.
+        assert_eq!(func.lambdas.len(), 1);
+
+        let root_body = func.root_body();
+        let region = &func.regions[root_body];
+        assert_eq!(region.args.len(), 2);  // %cs, %os
+        assert_eq!(region.nodes.len(), 3); // BoundsCheck, ReadBytes, WriteToField
+        assert_eq!(region.results.len(), 2);
+    }
+
+    #[test]
+    fn parse_const_arithmetic() {
+        let input = r#"
+lambda @0 (shape: "u8") {
+  region {
+    args: [%cs, %os]
+    n0 = Const(0x2a) [] -> [v0]
+    n1 = Const(0x10) [] -> [v1]
+    n2 = Add [v0, v1] -> [v2]
+    n3 = WriteToField(offset=0, W8) [v2, %os:arg] -> [%os]
+    results: [%cs:arg, %os:n3]
+  }
+}
+"#;
+
+        let registry = IntrinsicRegistry::empty();
+        let func = parse_ir(input, test_shape(), &registry).unwrap();
+
+        let root_body = func.root_body();
+        let region = &func.regions[root_body];
+        assert_eq!(region.nodes.len(), 4);
+
+        // Verify Const(0x2a) parsed correctly.
+        let node0 = &func.nodes[region.nodes[0]];
+        match &node0.kind {
+            NodeKind::Simple(IrOp::Const { value }) => assert_eq!(*value, 0x2a),
+            other => panic!("expected Const, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_gamma() {
+        let input = r#"
+lambda @0 (shape: "u8") {
+  region {
+    args: [%cs, %os]
+    n0 = Const(0x0) [] -> [v0]
+    n1 = gamma [
+      pred: v0
+      in0: %cs:arg
+      in1: %os:arg
+    ] {
+      branch 0:
+        region {
+          args: [%cs, %os]
+          n2 = Const(0x2a) [] -> [v1]
+          results: [v1, %cs:arg, %os:arg]
+        }
+      branch 1:
+        region {
+          args: [%cs, %os]
+          n3 = Const(0x63) [] -> [v2]
+          results: [v2, %cs:arg, %os:arg]
+        }
+    } -> [v3, %cs, %os]
+    n4 = WriteToField(offset=0, W4) [v3, %os:n1] -> [%os]
+    results: [%cs:n1, %os:n4]
+  }
+}
+"#;
+
+        let registry = IntrinsicRegistry::empty();
+        let func = parse_ir(input, test_shape(), &registry).unwrap();
+
+        let root_body = func.root_body();
+        let region = &func.regions[root_body];
+        assert_eq!(region.nodes.len(), 3); // Const, gamma, WriteToField
+
+        let gamma_node = &func.nodes[region.nodes[1]];
+        match &gamma_node.kind {
+            NodeKind::Gamma { regions } => {
+                assert_eq!(regions.len(), 2);
+            }
+            other => panic!("expected Gamma, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn round_trip_simple() {
+        // Build IR programmatically.
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+            rb.bounds_check(4);
+            let val = rb.read_bytes(4);
+            rb.write_to_field(val, 0, Width::W4);
+            rb.set_results(&[]);
+        }
+        let func = builder.finish();
+
+        // Display → parse → display, check equality.
+        let registry = IntrinsicRegistry::empty();
+        let text1 = format!("{}", func.display_with_registry(&registry));
+        let func2 = parse_ir(&text1, test_shape(), &registry).unwrap();
+        let text2 = format!("{}", func2.display_with_registry(&registry));
+
+        assert_eq!(text1, text2, "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}");
+    }
+
+    #[test]
+    fn round_trip_gamma() {
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+            let pred = rb.const_val(0);
+            let out = rb.gamma(pred, &[], 2, |branch_idx, bb| {
+                let val = if branch_idx == 0 {
+                    bb.const_val(42)
+                } else {
+                    bb.const_val(99)
+                };
+                bb.set_results(&[val]);
+            });
+            rb.write_to_field(out[0], 0, Width::W4);
+            rb.set_results(&[]);
+        }
+        let func = builder.finish();
+
+        let registry = IntrinsicRegistry::empty();
+        let text1 = format!("{}", func.display_with_registry(&registry));
+        let func2 = parse_ir(&text1, test_shape(), &registry).unwrap();
+        let text2 = format!("{}", func2.display_with_registry(&registry));
+
+        assert_eq!(text1, text2, "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}");
+    }
+
+    #[test]
+    fn round_trip_theta() {
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+            let init = rb.const_val(5);
+            let one = rb.const_val(1);
+            let _ = rb.theta(&[init, one], |bb| {
+                let args = bb.region_args(2);
+                let counter = args[0];
+                let one = args[1];
+                let next = bb.binop(IrOp::Sub, counter, one);
+                bb.set_results(&[next, next, one]);
+            });
+            rb.set_results(&[]);
+        }
+        let func = builder.finish();
+
+        let registry = IntrinsicRegistry::empty();
+        let text1 = format!("{}", func.display_with_registry(&registry));
+        let func2 = parse_ir(&text1, test_shape(), &registry).unwrap();
+        let text2 = format!("{}", func2.display_with_registry(&registry));
+
+        assert_eq!(text1, text2, "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}");
+    }
+
+    #[test]
+    fn parse_error_unknown_intrinsic() {
+        let input = r#"
+lambda @0 (shape: "u8") {
+  region {
+    args: [%cs, %os]
+    n0 = CallIntrinsic(@nonexistent, field_offset=0) [%cs:arg, %os:arg] -> [%cs, %os]
+    results: [%cs:n0, %os:n0]
+  }
+}
+"#;
+
+        let registry = IntrinsicRegistry::empty();
+        let result = parse_ir(input, test_shape(), &registry);
+        let err = match result {
+            Err(e) => e,
+            Ok(_) => panic!("expected error for unknown intrinsic"),
+        };
+        assert!(err.message.contains("nonexistent"), "error was: {}", err.message);
+    }
+
+    #[test]
+    fn parse_error_malformed() {
+        let input = "this is not valid IR at all";
+
+        let registry = IntrinsicRegistry::empty();
+        let result = parse_ir(input, test_shape(), &registry);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn round_trip_all_ops() {
+        // Test round-tripping all simple ops.
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+
+            // Cursor ops
+            rb.bounds_check(8);
+            let v0 = rb.read_bytes(4);
+            let _v1 = rb.peek_byte();
+            rb.advance_cursor(2);
+            rb.advance_cursor_by(v0);
+            let saved = rb.save_cursor();
+            rb.restore_cursor(saved);
+
+            // Output ops
+            let val = rb.const_val(42);
+            rb.write_to_field(val, 0, Width::W4);
+            let _read = rb.read_from_field(0, Width::W4);
+            let ptr = rb.save_out_ptr();
+            rb.set_out_ptr(ptr);
+
+            // Arithmetic
+            let a = rb.const_val(1);
+            let b = rb.const_val(2);
+            let _ = rb.binop(IrOp::Add, a, b);
+            let _ = rb.binop(IrOp::Sub, a, b);
+            let _ = rb.binop(IrOp::And, a, b);
+            let _ = rb.binop(IrOp::Or, a, b);
+            let _ = rb.binop(IrOp::Shr, a, b);
+            let _ = rb.binop(IrOp::Shl, a, b);
+            let _ = rb.binop(IrOp::Xor, a, b);
+            let _ = rb.binop(IrOp::CmpNe, a, b);
+            let _ = rb.unary(IrOp::ZigzagDecode { wide: false }, a);
+            let _ = rb.unary(IrOp::SignExtend { from_width: Width::W4 }, a);
+
+            // Stack ops
+            let slot = rb.alloc_slot();
+            let _ = rb.slot_addr(slot);
+
+            rb.set_results(&[]);
+        }
+        let func = builder.finish();
+
+        let registry = IntrinsicRegistry::empty();
+        let text1 = format!("{}", func.display_with_registry(&registry));
+        let func2 = parse_ir(&text1, test_shape(), &registry).unwrap();
+        let text2 = format!("{}", func2.display_with_registry(&registry));
+
+        assert_eq!(text1, text2, "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}");
+    }
+
+    #[test]
+    fn round_trip_with_intrinsics() {
+        let registry = IntrinsicRegistry::new();
+
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+            rb.bounds_check(1);
+            let func_ptr = registry
+                .func_by_name("kajit_read_bool")
+                .expect("kajit_read_bool should be in registry");
+            rb.call_intrinsic(func_ptr, &[], 0, false);
+            rb.set_results(&[]);
+        }
+        let func = builder.finish();
+
+        let text1 = format!("{}", func.display_with_registry(&registry));
+        assert!(
+            text1.contains("@kajit_read_bool"),
+            "display should use @name, got:\n{text1}"
+        );
+
+        let func2 = parse_ir(&text1, test_shape(), &registry).unwrap();
+        let text2 = format!("{}", func2.display_with_registry(&registry));
+
+        assert_eq!(text1, text2, "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}");
+    }
+}

--- a/src/json_intrinsics.rs
+++ b/src/json_intrinsics.rs
@@ -1905,3 +1905,186 @@ unsafe fn json_escape_bytes_to_ctx(ctx: &mut EncodeContext, bytes: &[u8]) {
         unsafe { enc_write_bytes(ctx, tail) };
     }
 }
+
+/// Returns all known JSON intrinsics as `(name, IntrinsicFn)` pairs.
+pub fn known_intrinsics() -> Vec<(&'static str, crate::ir::IntrinsicFn)> {
+    use crate::ir::IntrinsicFn;
+    vec![
+        (
+            "kajit_json_skip_ws",
+            IntrinsicFn(kajit_json_skip_ws as *const () as usize),
+        ),
+        (
+            "kajit_json_expect_object_start",
+            IntrinsicFn(kajit_json_expect_object_start as *const () as usize),
+        ),
+        (
+            "kajit_json_expect_colon",
+            IntrinsicFn(kajit_json_expect_colon as *const () as usize),
+        ),
+        (
+            "kajit_json_peek_after_ws",
+            IntrinsicFn(kajit_json_peek_after_ws as *const () as usize),
+        ),
+        (
+            "kajit_json_read_key",
+            IntrinsicFn(kajit_json_read_key as *const () as usize),
+        ),
+        (
+            "kajit_json_key_equals",
+            IntrinsicFn(kajit_json_key_equals as *const () as usize),
+        ),
+        (
+            "kajit_json_skip_value",
+            IntrinsicFn(kajit_json_skip_value as *const () as usize),
+        ),
+        (
+            "kajit_json_expect_object_end",
+            IntrinsicFn(kajit_json_expect_object_end as *const () as usize),
+        ),
+        (
+            "kajit_json_comma_or_end_object",
+            IntrinsicFn(kajit_json_comma_or_end_object as *const () as usize),
+        ),
+        (
+            "kajit_json_read_u8",
+            IntrinsicFn(kajit_json_read_u8 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_u16",
+            IntrinsicFn(kajit_json_read_u16 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_u32",
+            IntrinsicFn(kajit_json_read_u32 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_u64",
+            IntrinsicFn(kajit_json_read_u64 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_u128",
+            IntrinsicFn(kajit_json_read_u128 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_usize",
+            IntrinsicFn(kajit_json_read_usize as *const () as usize),
+        ),
+        (
+            "kajit_json_read_i8",
+            IntrinsicFn(kajit_json_read_i8 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_i16",
+            IntrinsicFn(kajit_json_read_i16 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_i32",
+            IntrinsicFn(kajit_json_read_i32 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_i64",
+            IntrinsicFn(kajit_json_read_i64 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_i128",
+            IntrinsicFn(kajit_json_read_i128 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_isize",
+            IntrinsicFn(kajit_json_read_isize as *const () as usize),
+        ),
+        (
+            "kajit_json_read_f32",
+            IntrinsicFn(kajit_json_read_f32 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_f64",
+            IntrinsicFn(kajit_json_read_f64 as *const () as usize),
+        ),
+        (
+            "kajit_json_read_bool",
+            IntrinsicFn(kajit_json_read_bool as *const () as usize),
+        ),
+        (
+            "kajit_json_read_string_value",
+            IntrinsicFn(kajit_json_read_string_value as *const () as usize),
+        ),
+        (
+            "kajit_json_read_str_value",
+            IntrinsicFn(kajit_json_read_str_value as *const () as usize),
+        ),
+        (
+            "kajit_json_read_cow_str_value",
+            IntrinsicFn(kajit_json_read_cow_str_value as *const () as usize),
+        ),
+        (
+            "kajit_json_read_char",
+            IntrinsicFn(kajit_json_read_char as *const () as usize),
+        ),
+        (
+            "kajit_json_finish_str_fast",
+            IntrinsicFn(kajit_json_finish_str_fast as *const () as usize),
+        ),
+        (
+            "kajit_json_finish_cow_str_fast",
+            IntrinsicFn(kajit_json_finish_cow_str_fast as *const () as usize),
+        ),
+        (
+            "kajit_json_string_with_escapes",
+            IntrinsicFn(kajit_json_string_with_escapes as *const () as usize),
+        ),
+        (
+            "kajit_json_cow_str_with_escapes",
+            IntrinsicFn(kajit_json_cow_str_with_escapes as *const () as usize),
+        ),
+        (
+            "kajit_json_key_slow_from_jit",
+            IntrinsicFn(kajit_json_key_slow_from_jit as *const () as usize),
+        ),
+        (
+            "kajit_json_error_expected_tag_key",
+            IntrinsicFn(kajit_json_error_expected_tag_key as *const () as usize),
+        ),
+        (
+            "kajit_json_expect_comma",
+            IntrinsicFn(kajit_json_expect_comma as *const () as usize),
+        ),
+        (
+            "kajit_json_expect_array_end",
+            IntrinsicFn(kajit_json_expect_array_end as *const () as usize),
+        ),
+        (
+            "kajit_json_expect_array_start",
+            IntrinsicFn(kajit_json_expect_array_start as *const () as usize),
+        ),
+        (
+            "kajit_json_comma_or_end_array",
+            IntrinsicFn(kajit_json_comma_or_end_array as *const () as usize),
+        ),
+        (
+            "kajit_json_write_f32",
+            IntrinsicFn(kajit_json_write_f32 as *const () as usize),
+        ),
+        (
+            "kajit_json_write_f64",
+            IntrinsicFn(kajit_json_write_f64 as *const () as usize),
+        ),
+        (
+            "kajit_json_write_bool",
+            IntrinsicFn(kajit_json_write_bool as *const () as usize),
+        ),
+        (
+            "kajit_json_write_char",
+            IntrinsicFn(kajit_json_write_char as *const () as usize),
+        ),
+        (
+            "kajit_json_write_unit",
+            IntrinsicFn(kajit_json_write_unit as *const () as usize),
+        ),
+        (
+            "kajit_json_write_string",
+            IntrinsicFn(kajit_json_write_string as *const () as usize),
+        ),
+    ]
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod format;
 pub mod intrinsics;
 pub mod ir;
 pub mod ir_backend;
+pub mod ir_parse;
 pub mod ir_passes;
 pub mod jit_debug;
 pub mod jit_f64;
@@ -17,6 +18,7 @@ mod pow10tab;
 pub mod recipe;
 pub mod regalloc_engine;
 pub mod regalloc_mir;
+pub mod regalloc_mir_parse;
 pub mod solver;
 
 use compiler::{CompiledDecoder, CompiledEncoder};

--- a/src/regalloc_mir_parse.rs
+++ b/src/regalloc_mir_parse.rs
@@ -1,0 +1,791 @@
+//! RA-MIR textual parser for kajit's register allocator IR.
+//!
+//! Parses the text format produced by `RaProgram::Display` back into
+//! an `RaProgram`.
+
+use chumsky::prelude::*;
+
+use crate::context::ErrorCode;
+use crate::ir::{IntrinsicFn, LambdaId, SlotId, VReg, Width};
+use crate::linearize::{BinOpKind, LinearOp, UnaryOpKind};
+use crate::regalloc_mir::{
+    BlockId, FixedReg, OperandKind, RaBlock, RaClobbers, RaEdge, RaFunction, RaInst, RaOperand,
+    RaProgram, RaTerminator, RegClass,
+};
+
+type Extra<'src> = extra::Err<Rich<'src, char>>;
+
+fn ws<'src>() -> impl Parser<'src, &'src str, (), Extra<'src>> + Clone {
+    any()
+        .filter(|c: &char| c.is_whitespace())
+        .repeated()
+        .ignored()
+}
+
+/// Horizontal whitespace only (spaces and tabs, not newlines).
+fn hws<'src>() -> impl Parser<'src, &'src str, (), Extra<'src>> + Clone {
+    any()
+        .filter(|c: &char| *c == ' ' || *c == '\t')
+        .repeated()
+        .ignored()
+}
+
+fn uint32<'src>() -> impl Parser<'src, &'src str, u32, Extra<'src>> + Clone {
+    text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u32>().unwrap())
+}
+
+fn uint64<'src>() -> impl Parser<'src, &'src str, u64, Extra<'src>> + Clone {
+    let hex = just("0x")
+        .ignore_then(text::int::<_, Extra<'_>>(16))
+        .map(|s: &str| u64::from_str_radix(s, 16).unwrap());
+    let dec = text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u64>().unwrap());
+    hex.or(dec)
+}
+
+fn usize_p<'src>() -> impl Parser<'src, &'src str, usize, Extra<'src>> + Clone {
+    let hex = just("0x")
+        .ignore_then(text::int::<_, Extra<'_>>(16))
+        .map(|s: &str| usize::from_str_radix(s, 16).unwrap());
+    let dec = text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<usize>().unwrap());
+    hex.or(dec)
+}
+
+fn width<'src>() -> impl Parser<'src, &'src str, Width, Extra<'src>> + Clone {
+    choice((
+        just("W1").to(Width::W1),
+        just("W2").to(Width::W2),
+        just("W4").to(Width::W4),
+        just("W8").to(Width::W8),
+    ))
+}
+
+fn error_code<'src>() -> impl Parser<'src, &'src str, ErrorCode, Extra<'src>> + Clone {
+    choice((
+        just("UnexpectedEof").to(ErrorCode::UnexpectedEof),
+        just("InvalidVarint").to(ErrorCode::InvalidVarint),
+        just("InvalidUtf8").to(ErrorCode::InvalidUtf8),
+        just("UnsupportedShape").to(ErrorCode::UnsupportedShape),
+        just("ExpectedObjectStart").to(ErrorCode::ExpectedObjectStart),
+        just("ExpectedColon").to(ErrorCode::ExpectedColon),
+        just("ExpectedStringKey").to(ErrorCode::ExpectedStringKey),
+        just("UnterminatedString").to(ErrorCode::UnterminatedString),
+        just("InvalidJsonNumber").to(ErrorCode::InvalidJsonNumber),
+        just("MissingRequiredField").to(ErrorCode::MissingRequiredField),
+        just("UnexpectedCharacter").to(ErrorCode::UnexpectedCharacter),
+        just("NumberOutOfRange").to(ErrorCode::NumberOutOfRange),
+        just("InvalidBool").to(ErrorCode::InvalidBool),
+        just("UnknownVariant").to(ErrorCode::UnknownVariant),
+        just("ExpectedTagKey").to(ErrorCode::ExpectedTagKey),
+        just("AmbiguousVariant").to(ErrorCode::AmbiguousVariant),
+        just("AllocError").to(ErrorCode::AllocError),
+        just("InvalidEscapeSequence").to(ErrorCode::InvalidEscapeSequence),
+        just("UnknownField").to(ErrorCode::UnknownField),
+    ))
+}
+
+fn vreg<'src>() -> impl Parser<'src, &'src str, VReg, Extra<'src>> + Clone {
+    just("v")
+        .ignore_then(uint32())
+        .map(|v| VReg::new(v))
+}
+
+fn block_id<'src>() -> impl Parser<'src, &'src str, BlockId, Extra<'src>> + Clone {
+    just("b").ignore_then(uint32()).map(BlockId)
+}
+
+fn reg_class<'src>() -> impl Parser<'src, &'src str, RegClass, Extra<'src>> + Clone {
+    choice((
+        just("gpr").to(RegClass::Gpr),
+        just("simd").to(RegClass::Simd),
+    ))
+}
+
+fn fixed_reg<'src>() -> impl Parser<'src, &'src str, FixedReg, Extra<'src>> + Clone {
+    let arg = just("/arg")
+        .ignore_then(text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u8>().unwrap()))
+        .map(FixedReg::AbiArg);
+    let ret = just("/ret")
+        .ignore_then(text::int::<_, Extra<'_>>(10).map(|s: &str| s.parse::<u8>().unwrap()))
+        .map(FixedReg::AbiRet);
+    arg.or(ret)
+}
+
+/// Parse an operand: `v0:gpr`, `v1:simd/arg2`, `v2:gpr/ret0`
+fn operand<'src>() -> impl Parser<'src, &'src str, (VReg, RegClass, Option<FixedReg>), Extra<'src>> + Clone
+{
+    vreg()
+        .then_ignore(just(":"))
+        .then(reg_class())
+        .then(fixed_reg().or_not())
+        .map(|((v, c), f)| (v, c, f))
+}
+
+/// Parse clobbers: `!gpr`, `!simd`, `!gpr,simd`
+fn clobbers<'src>() -> impl Parser<'src, &'src str, RaClobbers, Extra<'src>> + Clone {
+    just("!")
+        .ignore_then(choice((
+            just("gpr,simd").to(RaClobbers {
+                caller_saved_gpr: true,
+                caller_saved_simd: true,
+            }),
+            just("gpr").to(RaClobbers {
+                caller_saved_gpr: true,
+                caller_saved_simd: false,
+            }),
+            just("simd").to(RaClobbers {
+                caller_saved_gpr: false,
+                caller_saved_simd: true,
+            }),
+        )))
+}
+
+/// Parse an instruction line.
+/// Format: `[defs =] op_name [uses] [!clobbers]`
+fn instruction<'src>() -> impl Parser<'src, &'src str, AstInst, Extra<'src>> + Clone {
+    // Def operands before `=`, or none
+    // Use hws() (horizontal whitespace) so instructions don't span across lines.
+    let def_part = operand()
+        .separated_by(just(",").padded_by(hws()))
+        .at_least(1)
+        .collect::<Vec<_>>()
+        .then_ignore(hws().then(just("=")).then(hws()));
+
+    let use_part = operand()
+        .separated_by(just(",").padded_by(hws()))
+        .at_least(1)
+        .collect::<Vec<_>>();
+
+    let clobber_part = hws().ignore_then(clobbers()).or_not();
+
+    // With defs
+    let with_defs = def_part
+        .then(op_name())
+        .then(hws().ignore_then(use_part.clone()).or_not())
+        .then(clobber_part.clone())
+        .map(|(((defs, op), uses), clob)| AstInst {
+            defs,
+            op,
+            uses: uses.unwrap_or_default(),
+            clobbers: clob.unwrap_or_default(),
+        });
+
+    // Without defs (void ops like bounds_check, store, etc.)
+    let without_defs = op_name()
+        .then(hws().ignore_then(use_part).or_not())
+        .then(clobber_part)
+        .map(|((op, uses), clob)| AstInst {
+            defs: Vec::new(),
+            op,
+            uses: uses.unwrap_or_default(),
+            clobbers: clob.unwrap_or_default(),
+        });
+
+    with_defs.or(without_defs)
+}
+
+#[derive(Debug, Clone)]
+struct AstInst {
+    defs: Vec<(VReg, RegClass, Option<FixedReg>)>,
+    op: AstRaOp,
+    uses: Vec<(VReg, RegClass, Option<FixedReg>)>,
+    clobbers: RaClobbers,
+}
+
+/// Parsed operation name with params (to build LinearOp).
+#[derive(Debug, Clone)]
+enum AstRaOp {
+    Const(u64),
+    BinOp(BinOpKind),
+    UnaryOp(UnaryOpKind),
+    Copy,
+    BoundsCheck(u32),
+    ReadBytes(u32),
+    PeekByte,
+    Advance(u32),
+    AdvanceBy,
+    SaveCursor,
+    RestoreCursor,
+    Store(u32, Width),
+    Load(u32, Width),
+    SaveOutPtr,
+    SetOutPtr,
+    SlotAddr(u32),
+    WriteSlot(u32),
+    ReadSlot(u32),
+    CallIntrinsic(usize, u32),
+    CallPure(usize),
+    CallLambda(u32),
+    SimdStringScan,
+    SimdWsSkip,
+    ErrorExit(ErrorCode),
+}
+
+fn op_name<'src>() -> impl Parser<'src, &'src str, AstRaOp, Extra<'src>> + Clone {
+    let parameterized = choice((
+        just("const(")
+            .ignore_then(uint64())
+            .then_ignore(just(")"))
+            .map(AstRaOp::Const),
+        just("bounds_check(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::BoundsCheck),
+        just("read_bytes(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::ReadBytes),
+        just("advance(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::Advance),
+        just("store([")
+            .ignore_then(uint32())
+            .then_ignore(just(":"))
+            .then(width())
+            .then_ignore(just("])"))
+            .map(|(o, w)| AstRaOp::Store(o, w)),
+        just("load([")
+            .ignore_then(uint32())
+            .then_ignore(just(":"))
+            .then(width())
+            .then_ignore(just("])"))
+            .map(|(o, w)| AstRaOp::Load(o, w)),
+        just("slot_addr(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::SlotAddr),
+        just("write_slot(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::WriteSlot),
+        just("read_slot(")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::ReadSlot),
+        just("call_intrinsic(")
+            .ignore_then(usize_p())
+            .then_ignore(just(",").then(ws()).then(just("fo=")))
+            .then(uint32())
+            .then_ignore(just(")"))
+            .map(|(func, fo)| AstRaOp::CallIntrinsic(func, fo)),
+    ));
+
+    let parameterized2 = choice((
+        just("call_pure(")
+            .ignore_then(usize_p())
+            .then_ignore(just(")"))
+            .map(AstRaOp::CallPure),
+        just("call_lambda(@")
+            .ignore_then(uint32())
+            .then_ignore(just(")"))
+            .map(AstRaOp::CallLambda),
+        just("error_exit(")
+            .ignore_then(error_code())
+            .then_ignore(just(")"))
+            .map(AstRaOp::ErrorExit),
+    ));
+
+    let binops = choice((
+        just("Add").to(AstRaOp::BinOp(BinOpKind::Add)),
+        just("Sub").to(AstRaOp::BinOp(BinOpKind::Sub)),
+        just("And").to(AstRaOp::BinOp(BinOpKind::And)),
+        just("Or").to(AstRaOp::BinOp(BinOpKind::Or)),
+        just("Shr").to(AstRaOp::BinOp(BinOpKind::Shr)),
+        just("Shl").to(AstRaOp::BinOp(BinOpKind::Shl)),
+        just("Xor").to(AstRaOp::BinOp(BinOpKind::Xor)),
+        just("CmpNe").to(AstRaOp::BinOp(BinOpKind::CmpNe)),
+    ));
+
+    let unaryops = choice((
+        just("ZigzagDecode { wide: true }").to(AstRaOp::UnaryOp(UnaryOpKind::ZigzagDecode { wide: true })),
+        just("ZigzagDecode { wide: false }").to(AstRaOp::UnaryOp(UnaryOpKind::ZigzagDecode { wide: false })),
+        just("SignExtend { from_width: ")
+            .ignore_then(width())
+            .then_ignore(just(" }"))
+            .map(|w| AstRaOp::UnaryOp(UnaryOpKind::SignExtend { from_width: w })),
+    ));
+
+    let simple = choice((
+        just("copy").to(AstRaOp::Copy),
+        just("peek_byte").to(AstRaOp::PeekByte),
+        just("advance_by").to(AstRaOp::AdvanceBy),
+        just("save_cursor").to(AstRaOp::SaveCursor),
+        just("restore_cursor").to(AstRaOp::RestoreCursor),
+        just("save_out_ptr").to(AstRaOp::SaveOutPtr),
+        just("set_out_ptr").to(AstRaOp::SetOutPtr),
+        just("simd_string_scan").to(AstRaOp::SimdStringScan),
+        just("simd_ws_skip").to(AstRaOp::SimdWsSkip),
+    ));
+
+    choice((parameterized, parameterized2, binops, unaryops, simple))
+}
+
+fn terminator<'src>() -> impl Parser<'src, &'src str, RaTerminator, Extra<'src>> + Clone {
+    let ret = just("return").to(RaTerminator::Return);
+    let error = just("error_exit(")
+        .ignore_then(error_code())
+        .then_ignore(just(")"))
+        .map(|c| RaTerminator::ErrorExit { code: c });
+    let branch = just("branch ")
+        .ignore_then(block_id())
+        .map(|b| RaTerminator::Branch { target: b });
+    let branch_if = just("branch_if ")
+        .ignore_then(vreg())
+        .then_ignore(just(" -> "))
+        .then(block_id())
+        .then_ignore(just(", fallthrough "))
+        .then(block_id())
+        .map(|((cond, target), fallthrough)| RaTerminator::BranchIf {
+            cond,
+            target,
+            fallthrough,
+        });
+    let branch_if_zero = just("branch_if_zero ")
+        .ignore_then(vreg())
+        .then_ignore(just(" -> "))
+        .then(block_id())
+        .then_ignore(just(", fallthrough "))
+        .then(block_id())
+        .map(|((cond, target), fallthrough)| RaTerminator::BranchIfZero {
+            cond,
+            target,
+            fallthrough,
+        });
+    let jump_table = just("jump_table ")
+        .ignore_then(vreg())
+        .then_ignore(just(" ["))
+        .then(
+            block_id()
+                .separated_by(just(", "))
+                .collect::<Vec<_>>(),
+        )
+        .then_ignore(just("], default "))
+        .then(block_id())
+        .map(|((predicate, targets), default)| RaTerminator::JumpTable {
+            predicate,
+            targets,
+            default,
+        });
+
+    choice((branch_if_zero, branch_if, jump_table, error, branch, ret))
+}
+
+/// Parse successor edges: `succs: b1 [v0, v1] b2 [v2]` or `succs: (none)`
+fn succs<'src>() -> impl Parser<'src, &'src str, Vec<RaEdge>, Extra<'src>> + Clone {
+    let none = just("succs:").then(ws()).then(just("(none)")).to(Vec::new());
+    let edge = block_id()
+        .then(
+            just(" [")
+                .ignore_then(
+                    vreg()
+                        .separated_by(just(", "))
+                        .collect::<Vec<_>>(),
+                )
+                .then_ignore(just("]"))
+                .or_not(),
+        )
+        .map(|(to, args)| RaEdge {
+            to,
+            args: args.unwrap_or_default(),
+        });
+    let some = just("succs:")
+        .ignore_then(ws().ignore_then(edge).repeated().at_least(1).collect::<Vec<_>>());
+    none.or(some)
+}
+
+/// Parse block params: `[params: v0, v1]`
+fn block_params<'src>() -> impl Parser<'src, &'src str, Vec<VReg>, Extra<'src>> + Clone {
+    just("[params:")
+        .ignore_then(ws())
+        .ignore_then(
+            vreg()
+                .separated_by(just(",").then(ws()))
+                .collect::<Vec<_>>(),
+        )
+        .then_ignore(just("]"))
+}
+
+/// Parse block preds: `(preds: b0, b1)`
+fn block_preds<'src>() -> impl Parser<'src, &'src str, Vec<BlockId>, Extra<'src>> + Clone {
+    just("(preds:")
+        .ignore_then(ws())
+        .ignore_then(
+            block_id()
+                .separated_by(just(",").then(ws()))
+                .collect::<Vec<_>>(),
+        )
+        .then_ignore(just(")"))
+}
+
+fn block<'src>() -> impl Parser<'src, &'src str, AstBlock, Extra<'src>> + Clone {
+    just("block")
+        .padded_by(ws())
+        .ignore_then(block_id())
+        .then(ws().ignore_then(block_params()).or_not())
+        .then(ws().ignore_then(block_preds()).or_not())
+        .then_ignore(just(":").then(ws()))
+        .then(instruction().padded_by(ws()).repeated().collect::<Vec<_>>())
+        .then_ignore(just("term:").then(ws()))
+        .then(terminator())
+        .then_ignore(ws())
+        .then(succs())
+        .map(
+            |(((((id, params), preds), insts), term), succs)| AstBlock {
+                id,
+                params: params.unwrap_or_default(),
+                preds: preds.unwrap_or_default(),
+                insts,
+                term,
+                succs,
+            },
+        )
+}
+
+#[derive(Debug, Clone)]
+struct AstBlock {
+    id: BlockId,
+    params: Vec<VReg>,
+    preds: Vec<BlockId>,
+    insts: Vec<AstInst>,
+    term: RaTerminator,
+    succs: Vec<RaEdge>,
+}
+
+fn ra_func<'src>() -> impl Parser<'src, &'src str, AstRaFunc, Extra<'src>> + Clone {
+    just("ra_func")
+        .padded_by(ws())
+        .ignore_then(just("@"))
+        .ignore_then(uint32())
+        .then_ignore(ws().then(just("{")).then(ws()))
+        .then(block().padded_by(ws()).repeated().collect::<Vec<_>>())
+        .then_ignore(ws().then(just("}")))
+        .map(|(lambda_id, blocks)| AstRaFunc { lambda_id, blocks })
+}
+
+#[derive(Debug, Clone)]
+struct AstRaFunc {
+    lambda_id: u32,
+    blocks: Vec<AstBlock>,
+}
+
+fn ra_program<'src>() -> impl Parser<'src, &'src str, Vec<AstRaFunc>, Extra<'src>> + Clone {
+    ra_func()
+        .padded_by(ws())
+        .repeated()
+        .at_least(1)
+        .collect::<Vec<_>>()
+        .then_ignore(end())
+}
+
+// ─── Resolution ─────────────────────────────────────────────────────────────
+
+#[derive(Debug)]
+pub struct ParseError {
+    pub message: String,
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+/// Parse RA-MIR text format into an `RaProgram`.
+pub fn parse_ra_mir(input: &str) -> Result<RaProgram, ParseError> {
+    let result = ra_program().parse(input);
+    let funcs_ast = result.into_result().map_err(|errs| {
+        let msgs: Vec<String> = errs.into_iter().map(|e| format!("{e}")).collect();
+        ParseError {
+            message: msgs.join("\n"),
+        }
+    })?;
+
+    resolve(funcs_ast)
+}
+
+fn resolve(funcs_ast: Vec<AstRaFunc>) -> Result<RaProgram, ParseError> {
+    let mut max_vreg: u32 = 0;
+    let mut max_slot: u32 = 0;
+    let mut funcs = Vec::new();
+
+    for ast_func in funcs_ast {
+        let mut blocks = Vec::new();
+        for ast_block in ast_func.blocks {
+            let mut insts = Vec::new();
+            for (inst_idx, ast_inst) in ast_block.insts.iter().enumerate() {
+                let (op, operands) = resolve_inst(ast_inst, &mut max_vreg, &mut max_slot);
+                insts.push(RaInst {
+                    linear_op_index: inst_idx,
+                    op,
+                    operands,
+                    clobbers: ast_inst.clobbers,
+                });
+            }
+
+            // Track vregs in params.
+            for p in &ast_block.params {
+                max_vreg = max_vreg.max(p.index() as u32);
+            }
+
+            blocks.push(RaBlock {
+                id: ast_block.id,
+                label: None,
+                params: ast_block.params,
+                insts,
+                term_linear_op_index: None,
+                term: ast_block.term,
+                preds: ast_block.preds,
+                succs: ast_block.succs,
+            });
+        }
+
+        funcs.push(RaFunction {
+            lambda_id: LambdaId::new(ast_func.lambda_id),
+            entry: BlockId(0),
+            data_args: Vec::new(),
+            data_results: Vec::new(),
+            blocks,
+        });
+    }
+
+    Ok(RaProgram {
+        funcs,
+        vreg_count: max_vreg + 1,
+        slot_count: max_slot + 1,
+    })
+}
+
+fn resolve_inst(
+    ast: &AstInst,
+    max_vreg: &mut u32,
+    max_slot: &mut u32,
+) -> (LinearOp, Vec<RaOperand>) {
+    let mut operands = Vec::new();
+
+    // Build use operands.
+    for (v, class, fixed) in &ast.uses {
+        *max_vreg = (*max_vreg).max(v.index() as u32);
+        operands.push(RaOperand {
+            vreg: *v,
+            kind: OperandKind::Use,
+            class: *class,
+            fixed: *fixed,
+        });
+    }
+
+    // Build def operands.
+    for (v, class, fixed) in &ast.defs {
+        *max_vreg = (*max_vreg).max(v.index() as u32);
+        operands.push(RaOperand {
+            vreg: *v,
+            kind: OperandKind::Def,
+            class: *class,
+            fixed: *fixed,
+        });
+    }
+
+    // Build the LinearOp from the parsed op + operand info.
+    let dst = ast.defs.first().map(|(v, _, _)| *v);
+    let src = ast.uses.first().map(|(v, _, _)| *v);
+
+    let op = match &ast.op {
+        AstRaOp::Const(value) => LinearOp::Const {
+            dst: dst.unwrap(),
+            value: *value,
+        },
+        AstRaOp::BinOp(kind) => {
+            let lhs = ast.uses[0].0;
+            let rhs = ast.uses[1].0;
+            LinearOp::BinOp {
+                op: *kind,
+                dst: dst.unwrap(),
+                lhs,
+                rhs,
+            }
+        }
+        AstRaOp::UnaryOp(kind) => LinearOp::UnaryOp {
+            op: kind.clone(),
+            dst: dst.unwrap(),
+            src: src.unwrap(),
+        },
+        AstRaOp::Copy => LinearOp::Copy {
+            dst: dst.unwrap(),
+            src: src.unwrap(),
+        },
+        AstRaOp::BoundsCheck(count) => LinearOp::BoundsCheck { count: *count },
+        AstRaOp::ReadBytes(count) => LinearOp::ReadBytes {
+            dst: dst.unwrap(),
+            count: *count,
+        },
+        AstRaOp::PeekByte => LinearOp::PeekByte { dst: dst.unwrap() },
+        AstRaOp::Advance(count) => LinearOp::AdvanceCursor { count: *count },
+        AstRaOp::AdvanceBy => LinearOp::AdvanceCursorBy { src: src.unwrap() },
+        AstRaOp::SaveCursor => LinearOp::SaveCursor { dst: dst.unwrap() },
+        AstRaOp::RestoreCursor => LinearOp::RestoreCursor { src: src.unwrap() },
+        AstRaOp::Store(offset, width) => LinearOp::WriteToField {
+            src: src.unwrap(),
+            offset: *offset,
+            width: *width,
+        },
+        AstRaOp::Load(offset, width) => LinearOp::ReadFromField {
+            dst: dst.unwrap(),
+            offset: *offset,
+            width: *width,
+        },
+        AstRaOp::SaveOutPtr => LinearOp::SaveOutPtr { dst: dst.unwrap() },
+        AstRaOp::SetOutPtr => LinearOp::SetOutPtr { src: src.unwrap() },
+        AstRaOp::SlotAddr(slot) => {
+            *max_slot = (*max_slot).max(*slot);
+            LinearOp::SlotAddr {
+                dst: dst.unwrap(),
+                slot: SlotId::new(*slot),
+            }
+        }
+        AstRaOp::WriteSlot(slot) => {
+            *max_slot = (*max_slot).max(*slot);
+            LinearOp::WriteToSlot {
+                slot: SlotId::new(*slot),
+                src: src.unwrap(),
+            }
+        }
+        AstRaOp::ReadSlot(slot) => {
+            *max_slot = (*max_slot).max(*slot);
+            LinearOp::ReadFromSlot {
+                dst: dst.unwrap(),
+                slot: SlotId::new(*slot),
+            }
+        }
+        AstRaOp::CallIntrinsic(func, fo) => {
+            let args: Vec<VReg> = ast.uses.iter().map(|(v, _, _)| *v).collect();
+            LinearOp::CallIntrinsic {
+                func: IntrinsicFn(*func),
+                args,
+                dst,
+                field_offset: *fo,
+            }
+        }
+        AstRaOp::CallPure(func) => {
+            let args: Vec<VReg> = ast.uses.iter().map(|(v, _, _)| *v).collect();
+            LinearOp::CallPure {
+                func: IntrinsicFn(*func),
+                args,
+                dst: dst.unwrap(),
+            }
+        }
+        AstRaOp::CallLambda(target) => {
+            let args: Vec<VReg> = ast.uses.iter().map(|(v, _, _)| *v).collect();
+            let results: Vec<VReg> = ast.defs.iter().map(|(v, _, _)| *v).collect();
+            LinearOp::CallLambda {
+                target: LambdaId::new(*target),
+                args,
+                results,
+            }
+        }
+        AstRaOp::SimdStringScan => {
+            let pos = ast.defs[0].0;
+            let kind = ast.defs[1].0;
+            LinearOp::SimdStringScan { pos, kind }
+        }
+        AstRaOp::SimdWsSkip => LinearOp::SimdWhitespaceSkip,
+        AstRaOp::ErrorExit(code) => LinearOp::ErrorExit { code: *code },
+    };
+
+    (op, operands)
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{IrBuilder, Width};
+    use crate::linearize::linearize;
+    use crate::regalloc_mir::lower_linear_ir;
+
+    fn test_shape() -> &'static facet::Shape {
+        <u8 as facet::Facet>::SHAPE
+    }
+
+    #[test]
+    fn parse_simple_ra_mir() {
+        let input = r#"
+ra_func @0 {
+  block b0:
+    v0:gpr = const(0x2a)
+    store([0:W4]) v0:gpr
+    term: return
+    succs: (none)
+}
+"#;
+
+        let prog = parse_ra_mir(input).unwrap();
+        assert_eq!(prog.funcs.len(), 1);
+        assert_eq!(prog.funcs[0].blocks.len(), 1);
+        assert_eq!(prog.funcs[0].blocks[0].insts.len(), 2);
+    }
+
+    #[test]
+    fn round_trip_ra_mir() {
+        // Build IR, linearize, lower to RA-MIR, display, parse, display again.
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+            rb.bounds_check(4);
+            let val = rb.read_bytes(4);
+            rb.write_to_field(val, 0, Width::W4);
+            rb.set_results(&[]);
+        }
+        let mut func = builder.finish();
+        let lin = linearize(&mut func);
+        let ra = lower_linear_ir(&lin);
+
+        let text1 = format!("{ra}");
+        let ra2 = parse_ra_mir(&text1).unwrap();
+        let text2 = format!("{ra2}");
+
+        assert_eq!(
+            text1, text2,
+            "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}"
+        );
+    }
+
+    #[test]
+    fn round_trip_ra_mir_with_branches() {
+        let mut builder = IrBuilder::new(test_shape());
+        {
+            let mut rb = builder.root_region();
+            let pred = rb.const_val(0);
+            let out = rb.gamma(pred, &[], 2, |branch_idx, bb| {
+                let val = if branch_idx == 0 {
+                    bb.const_val(42)
+                } else {
+                    bb.const_val(99)
+                };
+                bb.set_results(&[val]);
+            });
+            rb.write_to_field(out[0], 0, Width::W4);
+            rb.set_results(&[]);
+        }
+        let mut func = builder.finish();
+        let lin = linearize(&mut func);
+        let ra = lower_linear_ir(&lin);
+
+        let text1 = format!("{ra}");
+        let ra2 = parse_ra_mir(&text1).unwrap();
+        let text2 = format!("{ra2}");
+
+        assert_eq!(
+            text1, text2,
+            "round trip failed:\n--- original ---\n{text1}\n--- reparsed ---\n{text2}"
+        );
+    }
+
+    #[test]
+    fn parse_error_malformed_ra_mir() {
+        let input = "not valid ra-mir";
+        let result = parse_ra_mir(input);
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary

Adds chumsky-based text parsers that can round-trip the human-readable formats produced by `IrFunc::Display` and `RaProgram::Display` back into their in-memory IR representations. This enables testing, debugging, and hand-writing IR snippets in text form.

## Changes

- **New `ir_parse` module**: Parser for the RVSDG text format (lambdas, simple nodes, gamma/theta regions, all IR ops including intrinsic calls by `@name`)
- **New `regalloc_mir_parse` module**: Parser for the RA-MIR text format (blocks, instructions, operands, terminators, successor edges)
- **`IntrinsicRegistry`**: Bidirectional name-to-function-pointer registry that collects all postcard and JSON intrinsics, used by both display and parsing
- **`IrFuncDisplay` wrapper**: Prints intrinsic calls as `@kajit_read_u64` instead of raw hex addresses when a registry is provided
- **`Display` impls for RA-MIR**: `RaProgram`, `RaFunction`, blocks, instructions, operands, and terminators
- **`known_intrinsics()`**: Exported from both `intrinsics.rs` and `json_intrinsics.rs` to feed the registry
- **Visibility**: `vreg_count` and `slot_count` on `IrFunc` widened to `pub(crate)` for parser construction
- **Dependency**: Added `chumsky = "1.0.0-alpha.8"` for the parser combinators

## Test plan

- [ ] `cargo check` / `cargo build` passes
- [ ] Round-trip tests: display an IR, parse it back, re-display, assert text equality
- [ ] Verify intrinsic name resolution in both display and parse directions