### PR TITLE
RA-MIR readability pass: semantic comments + follow-ups for 132/133/134

### DIFF
--- a/kajit-mir/src/regalloc_mir.rs
+++ b/kajit-mir/src/regalloc_mir.rs
@@ -154,30 +154,90 @@ pub struct RaProgram {
 
 // ─── Display ────────────────────────────────────────────────────────────────
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DisplayStyle {
+    Canonical,
+    Human,
+}
+
+pub struct HumanRaProgram<'a> {
+    program: &'a RaProgram,
+}
+
+impl<'a> std::fmt::Display for HumanRaProgram<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt_program(self.program, f, DisplayStyle::Human)
+    }
+}
+
+impl RaProgram {
+    pub fn human(&self) -> HumanRaProgram<'_> {
+        HumanRaProgram { program: self }
+    }
+}
+
 impl std::fmt::Display for RaProgram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fmt_program(self, f)
+        let style = if f.alternate() {
+            DisplayStyle::Human
+        } else {
+            DisplayStyle::Canonical
+        };
+        fmt_program(self, f, style)
     }
 }
 
 impl std::fmt::Display for RaFunction {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        fmt_function(self, f)
+        let style = if f.alternate() {
+            DisplayStyle::Human
+        } else {
+            DisplayStyle::Canonical
+        };
+        fmt_function(self, f, style)
     }
 }
 
-fn fmt_program(program: &RaProgram, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+fn fmt_program(
+    program: &RaProgram,
+    f: &mut std::fmt::Formatter<'_>,
+    style: DisplayStyle,
+) -> std::fmt::Result {
     for func in &program.funcs {
-        fmt_function(func, f)?;
+        fmt_function(func, f, style)?;
     }
     Ok(())
 }
 
-fn fmt_function(func: &RaFunction, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+fn fmt_function(
+    func: &RaFunction,
+    f: &mut std::fmt::Formatter<'_>,
+    style: DisplayStyle,
+) -> std::fmt::Result {
+    match style {
+        DisplayStyle::Canonical => fmt_function_canonical(func, f),
+        DisplayStyle::Human => fmt_function_human(func, f),
+    }
+}
+
+fn fmt_function_canonical(func: &RaFunction, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    writeln!(
+        f,
+        "ra_func @{} {{ ; entry: b{}",
+        func.lambda_id.index(),
+        func.entry.0,
+    )?;
+    for block in &func.blocks {
+        fmt_block_canonical(f, block)?;
+    }
+    writeln!(f, "}}")
+}
+
+fn fmt_function_human(func: &RaFunction, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     let meta = build_display_meta(func);
     write!(
         f,
-        "ra_func @{} {{ ; entry: b{}",
+        "ra_func @{} (entry: b{})",
         func.lambda_id.index(),
         func.entry.0,
     )?;
@@ -190,12 +250,70 @@ fn fmt_function(func: &RaFunction, f: &mut std::fmt::Formatter<'_>) -> std::fmt:
     }
     writeln!(f)?;
     for block in &func.blocks {
-        fmt_block(f, block, &meta)?;
+        fmt_block_human(f, block, &meta)?;
+        writeln!(f)?;
     }
-    writeln!(f, "}}")
+    Ok(())
 }
 
-fn fmt_block(
+fn fmt_block_canonical(f: &mut std::fmt::Formatter<'_>, block: &RaBlock) -> std::fmt::Result {
+    write!(f, "  block b{}", block.id.0)?;
+    if !block.params.is_empty() {
+        write!(f, " [params:")?;
+        for (i, p) in block.params.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, " v{}", p.index())?;
+        }
+        write!(f, "]")?;
+    }
+    if !block.preds.is_empty() {
+        write!(f, " (preds:")?;
+        for (i, p) in block.preds.iter().enumerate() {
+            if i > 0 {
+                write!(f, ",")?;
+            }
+            write!(f, " b{}", p.0)?;
+        }
+        write!(f, ")")?;
+    }
+    writeln!(f, ": ; insts: {}", block.insts.len())?;
+
+    for inst in &block.insts {
+        write!(f, "    ")?;
+        fmt_ra_inst(f, inst)?;
+        writeln!(f)?;
+    }
+
+    write!(f, "    term: ")?;
+    fmt_terminator(f, &block.term)?;
+    writeln!(f, " ; uses: {}", fmt_vregs(&block.term.uses()))?;
+
+    if block.succs.is_empty() {
+        writeln!(f, "    succs: (none)")?;
+    } else {
+        write!(f, "    succs:")?;
+        for edge in &block.succs {
+            write!(f, " b{}", edge.to.0)?;
+            if !edge.args.is_empty() {
+                write!(f, " [")?;
+                for (i, arg) in edge.args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "v{}", arg.index())?;
+                }
+                write!(f, "]")?;
+            }
+        }
+        writeln!(f, " ; count: {}", block.succs.len())?;
+    }
+
+    Ok(())
+}
+
+fn fmt_block_human(
     f: &mut std::fmt::Formatter<'_>,
     block: &RaBlock,
     meta: &DisplayMeta,
@@ -1429,7 +1547,7 @@ mod tests {
     }
 
     #[test]
-    fn ra_mir_single_display_mode_with_comments() {
+    fn ra_mir_canonical_and_human_display_modes() {
         let mut builder = IrBuilder::new(<u32 as facet::Facet>::SHAPE);
         {
             let mut rb = builder.root_region();
@@ -1449,16 +1567,22 @@ mod tests {
         let lin = linearize(&mut func);
         let ra = lower_linear_ir(&lin);
 
-        let text = format!("{ra}");
-        assert!(text.starts_with("ra_func @0 { ; entry: b0"));
-        assert!(text.contains(" ; consts: "));
-        assert!(text.contains(" ; insts: "));
-        assert!(text.contains(" ; params_dbg: "));
-        assert!(text.contains(" ; uses: "));
-        assert!(text.contains(" ; orig: lir#"));
-        assert!(text.contains(" ; sem: "));
-        assert!(text.contains(" ; const_alias: "));
-        assert!(text.contains(" ; defs_dbg: "));
-        assert!(text.contains("term:"));
+        let canonical = format!("{ra}");
+        let human_alt = format!("{ra:#}");
+        let human_wrapper = format!("{}", ra.human());
+
+        assert!(canonical.starts_with("ra_func @0 { ; entry: b0"));
+        assert!(canonical.contains(" ; insts: "));
+        assert!(canonical.contains(" ; uses: "));
+        assert!(canonical.contains("term:"));
+        assert!(!canonical.contains(" ; sem: "));
+        assert!(!canonical.contains(" ; const_alias: "));
+
+        assert!(human_alt.starts_with("ra_func @0 (entry: b0)"));
+        assert!(human_alt.contains(" ; consts: "));
+        assert!(human_alt.contains(" ; sem: "));
+        assert!(human_alt.contains(" ; const_alias: "));
+        assert!(human_alt.contains(" ; defs_dbg: "));
+        assert_eq!(human_alt, human_wrapper);
     }
 }

--- a/kajit/src/lib.rs
+++ b/kajit/src/lib.rs
@@ -108,6 +108,20 @@ pub fn debug_ir_and_ra_mir_text(
     (ir_text, ra_text)
 }
 
+/// Build decoder IR (after default pre-regalloc passes) and return a human-readable RA-MIR dump.
+///
+/// This renderer is intended for interactive debugging and LLM-assisted analysis.
+pub fn debug_ra_mir_human_text(
+    shape: &'static facet::Shape,
+    ir_decoder: &dyn format::Decoder,
+) -> String {
+    let mut func = compiler::build_decoder_ir(shape, ir_decoder);
+    ir_passes::run_default_passes(&mut func);
+    let linear = linearize::linearize(&mut func);
+    let ra = regalloc_mir::lower_linear_ir(&linear);
+    scrub_volatile_intrinsic_addrs(&format!("{}", ra.human()))
+}
+
 /// Build decoder IR (after default pre-regalloc passes) and return textual Linear IR dump.
 ///
 /// Intended for snapshot tests and debugging.

--- a/kajit/tests/mir_text_regression.rs
+++ b/kajit/tests/mir_text_regression.rs
@@ -11,103 +11,113 @@ fn run_mir<'a, T: Facet<'a>>(mir_text: &str, input: &'a [u8]) -> Result<T, kajit
 }
 
 const POSTCARD_U32_V0_X86_64_MIR: &str = r#"
-ra_func @0 { ; entry: b0 ; consts: k0=0x7f, k1=0x80, k2=0x0, k3=0x20, k4=0x4, k5=0x7, k6=0x1
+ra_func @0 { ; entry: b0
   block b0: ; insts: 11
-    bounds_check(1) ; orig: lir#0 ; sem: ensure 1 input byte(s) available
-    v1:gpr = const(0x7f) ; orig: lir#1 ; sem: materialize constant 0x7f ; const_alias: k0 ; defs_dbg: t1=v1
-    v3:gpr = const(0x80) ; orig: lir#2 ; sem: materialize constant 0x80 ; const_alias: k1 ; defs_dbg: t3=v3
-    v5:gpr = const(0x0) ; orig: lir#3 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t5=v5
-    v37:gpr = const(0x0) ; orig: lir#4 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t37=v37
-    v39:gpr = const(0x20) ; orig: lir#5 ; sem: materialize constant 0x20 ; const_alias: k3 ; defs_dbg: t39=v39
-    v41:gpr = const(0x0) ; orig: lir#6 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t41=v41
-    v0:gpr = read_bytes(1) ; orig: lir#7 ; sem: consume 1 input byte(s) ; defs_dbg: t0=v0
-    v2:gpr = And v0:gpr, v1:gpr ; orig: lir#8 ; sem: bitwise and ; defs_dbg: t2=v2
-    v4:gpr = And v0:gpr, v3:gpr ; orig: lir#9 ; sem: bitwise and ; defs_dbg: t4=v4
-    v6:gpr = CmpNe v4:gpr, v5:gpr ; orig: lir#10 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t6=v6
-    term: branch_if_zero v6 -> b2, fallthrough b1 ; uses: [v6] ; orig: lir#11 ; sem: branch when condition is zero
+    bounds_check(1)
+    v1:gpr = const(0x7f)
+    v3:gpr = const(0x80)
+    v5:gpr = const(0x0)
+    v37:gpr = const(0x0)
+    v39:gpr = const(0x20)
+    v41:gpr = const(0x0)
+    v0:gpr = read_bytes(1)
+    v2:gpr = And v0:gpr, v1:gpr
+    v4:gpr = And v0:gpr, v3:gpr
+    v6:gpr = CmpNe v4:gpr, v5:gpr
+    term: branch_if_zero v6 -> b2, fallthrough b1 ; uses: [v6]
     succs: b2 [v2, v37, v39, v41] b1 [v2, v37, v39, v41] ; count: 2
-  block b1 [params: v2, v37, v39, v41] (preds: b0): ; insts: 0 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
-    term: branch b3 ; uses: [] ; orig: lir#12 ; sem: unconditional jump
+  block b1 [params: v2, v37, v39, v41] (preds: b0): ; insts: 0
+    term: branch b3 ; uses: []
     succs: b3 [v2, v37, v39, v41] ; count: 1
-  block b2 [params: v2, v37, v39, v41] (preds: b0): ; insts: 4 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
-    v7:gpr = const(0x4) ; orig: lir#13 ; sem: materialize constant 0x4 ; const_alias: k4 ; defs_dbg: t7=v7
-    v8:gpr = const(0x0) ; orig: lir#14 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t8=v8
-    v33:gpr = copy v2:gpr ; orig: lir#15 ; sem: ssa copy/move ; defs_dbg: t33=v33
-    v36:gpr = copy v8:gpr ; orig: lir#16 ; sem: ssa copy/move ; defs_dbg: t36=v36
-    term: branch b6 ; uses: [] ; orig: lir#17 ; sem: unconditional jump
+  block b2 [params: v2, v37, v39, v41] (preds: b0): ; insts: 4
+    v7:gpr = const(0x4)
+    v8:gpr = const(0x0)
+    v33:gpr = copy v2:gpr
+    v36:gpr = copy v8:gpr
+    term: branch b6 ; uses: []
     succs: b6 [v33, v8, v37, v39, v41] ; count: 1
-  block b3 [params: v2, v37, v39, v41] (preds: b1): ; insts: 12 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
-    v9:gpr = const(0x7) ; orig: lir#18 ; sem: materialize constant 0x7 ; const_alias: k5 ; defs_dbg: t9=v9
-    v10:gpr = const(0x4) ; orig: lir#19 ; sem: materialize constant 0x4 ; const_alias: k4 ; defs_dbg: t10=v10
-    v11:gpr = const(0x1) ; orig: lir#20 ; sem: materialize constant 0x1 ; const_alias: k6 ; defs_dbg: t11=v11
-    v13:gpr = const(0x7f) ; orig: lir#21 ; sem: materialize constant 0x7f ; const_alias: k0 ; defs_dbg: t13=v13
-    v17:gpr = const(0x7) ; orig: lir#22 ; sem: materialize constant 0x7 ; const_alias: k5 ; defs_dbg: t17=v17
-    v19:gpr = const(0x1) ; orig: lir#23 ; sem: materialize constant 0x1 ; const_alias: k6 ; defs_dbg: t19=v19
-    v21:gpr = const(0x80) ; orig: lir#24 ; sem: materialize constant 0x80 ; const_alias: k1 ; defs_dbg: t21=v21
-    v23:gpr = const(0x0) ; orig: lir#25 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t23=v23
-    v25:gpr = const(0x0) ; orig: lir#26 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t25=v25
-    v45:gpr = copy v2:gpr ; orig: lir#27 ; sem: ssa copy/move ; defs_dbg: t45=v45
-    v46:gpr = copy v9:gpr ; orig: lir#28 ; sem: ssa copy/move ; defs_dbg: t46=v46
-    v47:gpr = copy v10:gpr ; orig: lir#29 ; sem: ssa copy/move ; defs_dbg: t47=v47
-    term: branch b4 ; uses: [] ; orig: lir#30 ; sem: unconditional jump
+  block b3 [params: v2, v37, v39, v41] (preds: b1): ; insts: 12
+    v9:gpr = const(0x7)
+    v10:gpr = const(0x4)
+    v11:gpr = const(0x1)
+    v13:gpr = const(0x7f)
+    v17:gpr = const(0x7)
+    v19:gpr = const(0x1)
+    v21:gpr = const(0x80)
+    v23:gpr = const(0x0)
+    v25:gpr = const(0x0)
+    v45:gpr = copy v2:gpr
+    v46:gpr = copy v9:gpr
+    v47:gpr = copy v10:gpr
+    term: branch b4 ; uses: []
     succs: b4 [v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] ; count: 1
-  block b4 [params: v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] (preds: b3, b4): ; insts: 16 ; params_dbg: p0=v13, p1=v17, p2=v19, p3=v21, p4=v23, p5=v25, p6=v37, p7=v39, p8=v41, p9=v45, p10=v46, p11=v47
-    bounds_check(1) ; orig: lir#31 ; sem: ensure 1 input byte(s) available
-    v18:gpr = Add v46:gpr, v17:gpr ; orig: lir#32 ; sem: integer addition ; defs_dbg: t18=v18
-    v20:gpr = Sub v47:gpr, v19:gpr ; orig: lir#33 ; sem: integer subtraction ; defs_dbg: t20=v20
-    v12:gpr = read_bytes(1) ; orig: lir#34 ; sem: consume 1 input byte(s) ; defs_dbg: t12=v12
-    v26:gpr = CmpNe v20:gpr, v25:gpr ; orig: lir#35 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t26=v26
-    v14:gpr = And v12:gpr, v13:gpr ; orig: lir#36 ; sem: bitwise and ; defs_dbg: t14=v14
-    v22:gpr = And v12:gpr, v21:gpr ; orig: lir#37 ; sem: bitwise and ; defs_dbg: t22=v22
-    v15:gpr = Shl v14:gpr, v46:gpr/hw1 ; orig: lir#38 ; sem: logical shift left ; defs_dbg: t15=v15
-    v24:gpr = CmpNe v22:gpr, v23:gpr ; orig: lir#39 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t24=v24
-    v16:gpr = Or v45:gpr, v15:gpr ; orig: lir#40 ; sem: bitwise or ; defs_dbg: t16=v16
-    v27:gpr = And v24:gpr, v26:gpr ; orig: lir#41 ; sem: bitwise and ; defs_dbg: t27=v27
-    v45:gpr = copy v16:gpr ; orig: lir#42 ; sem: ssa copy/move ; defs_dbg: t45=v45
-    v46:gpr = copy v18:gpr ; orig: lir#43 ; sem: ssa copy/move ; defs_dbg: t46=v46
-    v47:gpr = copy v20:gpr ; orig: lir#44 ; sem: ssa copy/move ; defs_dbg: t47=v47
-    v48:gpr = copy v14:gpr ; orig: lir#45 ; sem: ssa copy/move ; defs_dbg: t48=v48
-    v49:gpr = copy v24:gpr ; orig: lir#46 ; sem: ssa copy/move ; defs_dbg: t49=v49
-    term: branch_if v27 -> b4, fallthrough b5 ; uses: [v27] ; orig: lir#47 ; sem: branch when condition is non-zero
+  block b4 [params: v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] (preds: b3, b4): ; insts: 16
+    bounds_check(1)
+    v18:gpr = Add v46:gpr, v17:gpr
+    v20:gpr = Sub v47:gpr, v19:gpr
+    v12:gpr = read_bytes(1)
+    v26:gpr = CmpNe v20:gpr, v25:gpr
+    v14:gpr = And v12:gpr, v13:gpr
+    v22:gpr = And v12:gpr, v21:gpr
+    v15:gpr = Shl v14:gpr, v46:gpr/hw1
+    v24:gpr = CmpNe v22:gpr, v23:gpr
+    v16:gpr = Or v45:gpr, v15:gpr
+    v27:gpr = And v24:gpr, v26:gpr
+    v45:gpr = copy v16:gpr
+    v46:gpr = copy v18:gpr
+    v47:gpr = copy v20:gpr
+    v48:gpr = copy v14:gpr
+    v49:gpr = copy v24:gpr
+    term: branch_if v27 -> b4, fallthrough b5 ; uses: [v27]
     succs: b4 [v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] b5 [v37, v39, v41, v45, v49] ; count: 2
-  block b5 [params: v37, v39, v41, v45, v49] (preds: b4): ; insts: 2 ; params_dbg: p0=v37, p1=v39, p2=v41, p3=v45, p4=v49
-    v33:gpr = copy v45:gpr ; orig: lir#48 ; sem: ssa copy/move ; defs_dbg: t33=v33
-    v36:gpr = copy v49:gpr ; orig: lir#49 ; sem: ssa copy/move ; defs_dbg: t36=v36
-    term: branch b6 ; uses: [] ; orig: lir#50 ; sem: unconditional jump
+  block b5 [params: v37, v39, v41, v45, v49] (preds: b4): ; insts: 2
+    v33:gpr = copy v45:gpr
+    v36:gpr = copy v49:gpr
+    term: branch b6 ; uses: []
     succs: b6 [v33, v36, v37, v39, v41] ; count: 1
-  block b6 [params: v33, v36, v37, v39, v41] (preds: b2, b5): ; insts: 2 ; params_dbg: p0=v33, p1=v36, p2=v37, p3=v39, p4=v41
-    v38:gpr = CmpNe v36:gpr, v37:gpr ; orig: lir#51 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t38=v38
-    v40:gpr = Shr v33:gpr, v39:gpr/hw1 ; orig: lir#52 ; sem: logical shift right ; defs_dbg: t40=v40
-    term: branch_if_zero v38 -> b8, fallthrough b7 ; uses: [v38] ; orig: lir#53 ; sem: branch when condition is zero
+  block b6 [params: v33, v36, v37, v39, v41] (preds: b2, b5): ; insts: 2
+    v38:gpr = CmpNe v36:gpr, v37:gpr
+    v40:gpr = Shr v33:gpr, v39:gpr/hw1
+    term: branch_if_zero v38 -> b8, fallthrough b7 ; uses: [v38]
     succs: b8 [v33, v40, v41] b7 ; count: 2
   block b7 (preds: b6): ; insts: 0
-    term: branch b9 ; uses: [] ; orig: lir#54 ; sem: unconditional jump
+    term: branch b9 ; uses: []
     succs: b9 ; count: 1
-  block b8 [params: v33, v40, v41] (preds: b6): ; insts: 0 ; params_dbg: p0=v33, p1=v40, p2=v41
-    term: branch b10 ; uses: [] ; orig: lir#55 ; sem: unconditional jump
+  block b8 [params: v33, v40, v41] (preds: b6): ; insts: 0
+    term: branch b10 ; uses: []
     succs: b10 [v33, v40, v41] ; count: 1
   block b9 (preds: b7): ; insts: 0
-    term: error_exit(InvalidVarint) ; uses: [] ; orig: lir#56 ; sem: terminate with error
+    term: error_exit(InvalidVarint) ; uses: []
     succs: (none)
-  block b10 [params: v33, v40, v41] (preds: b8): ; insts: 1 ; params_dbg: p0=v33, p1=v40, p2=v41
-    v42:gpr = CmpNe v40:gpr, v41:gpr ; orig: lir#57 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t42=v42
-    term: branch_if_zero v42 -> b12, fallthrough b11 ; uses: [v42] ; orig: lir#58 ; sem: branch when condition is zero
+  block b10 [params: v33, v40, v41] (preds: b8): ; insts: 1
+    v42:gpr = CmpNe v40:gpr, v41:gpr
+    term: branch_if_zero v42 -> b12, fallthrough b11 ; uses: [v42]
     succs: b12 [v33] b11 ; count: 2
   block b11 (preds: b10): ; insts: 0
-    term: branch b13 ; uses: [] ; orig: lir#59 ; sem: unconditional jump
+    term: branch b13 ; uses: []
     succs: b13 ; count: 1
-  block b12 [params: v33] (preds: b10): ; insts: 0 ; params_dbg: p0=v33
-    term: branch b14 ; uses: [] ; orig: lir#60 ; sem: unconditional jump
+  block b12 [params: v33] (preds: b10): ; insts: 0
+    term: branch b14 ; uses: []
     succs: b14 [v33] ; count: 1
   block b13 (preds: b11): ; insts: 0
-    term: error_exit(NumberOutOfRange) ; uses: [] ; orig: lir#61 ; sem: terminate with error
+    term: error_exit(NumberOutOfRange) ; uses: []
     succs: (none)
-  block b14 [params: v33] (preds: b12): ; insts: 1 ; params_dbg: p0=v33
-    store([0:W4]) v33:gpr ; orig: lir#62 ; sem: write output field at +0 (W4)
-    term: return ; uses: [] ; orig: lir#63 ; sem: finish function
+  block b14 [params: v33] (preds: b12): ; insts: 1
+    store([0:W4]) v33:gpr
+    term: return ; uses: []
     succs: (none)
 }
 "#;
+
+#[test]
+fn postcard_u32_human_ra_mir_snapshot() {
+    let program =
+        kajit_mir_text::parse_ra_mir(POSTCARD_U32_V0_X86_64_MIR).expect("fixture should parse");
+    insta::assert_snapshot!(
+        "mir_text_regression__postcard_u32_v0_x86_64_human",
+        format!("{}", program.human())
+    );
+}
 
 /// Postcard varint decoder for u32 — single-byte case (value < 128).
 ///

--- a/kajit/tests/snapshots/corpus__generated_ra_mir_postcard_scalar_u32__v0_x86_64.snap
+++ b/kajit/tests/snapshots/corpus__generated_ra_mir_postcard_scalar_u32__v0_x86_64.snap
@@ -2,99 +2,99 @@
 source: kajit/tests/corpus.rs
 expression: ra_text
 ---
-ra_func @0 { ; entry: b0 ; consts: k0=0x7f, k1=0x80, k2=0x0, k3=0x20, k4=0x4, k5=0x7, k6=0x1
+ra_func @0 { ; entry: b0
   block b0: ; insts: 11
-    bounds_check(1) ; orig: lir#0 ; sem: ensure 1 input byte(s) available
-    v1:gpr = const(0x7f) ; orig: lir#1 ; sem: materialize constant 0x7f ; const_alias: k0 ; defs_dbg: t1=v1
-    v3:gpr = const(0x80) ; orig: lir#2 ; sem: materialize constant 0x80 ; const_alias: k1 ; defs_dbg: t3=v3
-    v5:gpr = const(0x0) ; orig: lir#3 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t5=v5
-    v37:gpr = const(0x0) ; orig: lir#4 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t37=v37
-    v39:gpr = const(0x20) ; orig: lir#5 ; sem: materialize constant 0x20 ; const_alias: k3 ; defs_dbg: t39=v39
-    v41:gpr = const(0x0) ; orig: lir#6 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t41=v41
-    v0:gpr = read_bytes(1) ; orig: lir#7 ; sem: consume 1 input byte(s) ; defs_dbg: t0=v0
-    v2:gpr = And v0:gpr, v1:gpr ; orig: lir#8 ; sem: bitwise and ; defs_dbg: t2=v2
-    v4:gpr = And v0:gpr, v3:gpr ; orig: lir#9 ; sem: bitwise and ; defs_dbg: t4=v4
-    v6:gpr = CmpNe v4:gpr, v5:gpr ; orig: lir#10 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t6=v6
-    term: branch_if_zero v6 -> b2, fallthrough b1 ; uses: [v6] ; orig: lir#11 ; sem: branch when condition is zero
+    bounds_check(1)
+    v1:gpr = const(0x7f)
+    v3:gpr = const(0x80)
+    v5:gpr = const(0x0)
+    v37:gpr = const(0x0)
+    v39:gpr = const(0x20)
+    v41:gpr = const(0x0)
+    v0:gpr = read_bytes(1)
+    v2:gpr = And v0:gpr, v1:gpr
+    v4:gpr = And v0:gpr, v3:gpr
+    v6:gpr = CmpNe v4:gpr, v5:gpr
+    term: branch_if_zero v6 -> b2, fallthrough b1 ; uses: [v6]
     succs: b2 [v2, v37, v39, v41] b1 [v2, v37, v39, v41] ; count: 2
-  block b1 [params: v2, v37, v39, v41] (preds: b0): ; insts: 0 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
-    term: branch b3 ; uses: [] ; orig: lir#12 ; sem: unconditional jump
+  block b1 [params: v2, v37, v39, v41] (preds: b0): ; insts: 0
+    term: branch b3 ; uses: []
     succs: b3 [v2, v37, v39, v41] ; count: 1
-  block b2 [params: v2, v37, v39, v41] (preds: b0): ; insts: 4 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
-    v7:gpr = const(0x4) ; orig: lir#13 ; sem: materialize constant 0x4 ; const_alias: k4 ; defs_dbg: t7=v7
-    v8:gpr = const(0x0) ; orig: lir#14 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t8=v8
-    v33:gpr = copy v2:gpr ; orig: lir#15 ; sem: ssa copy/move ; defs_dbg: t33=v33
-    v36:gpr = copy v8:gpr ; orig: lir#16 ; sem: ssa copy/move ; defs_dbg: t36=v36
-    term: branch b6 ; uses: [] ; orig: lir#17 ; sem: unconditional jump
+  block b2 [params: v2, v37, v39, v41] (preds: b0): ; insts: 4
+    v7:gpr = const(0x4)
+    v8:gpr = const(0x0)
+    v33:gpr = copy v2:gpr
+    v36:gpr = copy v8:gpr
+    term: branch b6 ; uses: []
     succs: b6 [v33, v8, v37, v39, v41] ; count: 1
-  block b3 [params: v2, v37, v39, v41] (preds: b1): ; insts: 12 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
-    v9:gpr = const(0x7) ; orig: lir#18 ; sem: materialize constant 0x7 ; const_alias: k5 ; defs_dbg: t9=v9
-    v10:gpr = const(0x4) ; orig: lir#19 ; sem: materialize constant 0x4 ; const_alias: k4 ; defs_dbg: t10=v10
-    v11:gpr = const(0x1) ; orig: lir#20 ; sem: materialize constant 0x1 ; const_alias: k6 ; defs_dbg: t11=v11
-    v13:gpr = const(0x7f) ; orig: lir#21 ; sem: materialize constant 0x7f ; const_alias: k0 ; defs_dbg: t13=v13
-    v17:gpr = const(0x7) ; orig: lir#22 ; sem: materialize constant 0x7 ; const_alias: k5 ; defs_dbg: t17=v17
-    v19:gpr = const(0x1) ; orig: lir#23 ; sem: materialize constant 0x1 ; const_alias: k6 ; defs_dbg: t19=v19
-    v21:gpr = const(0x80) ; orig: lir#24 ; sem: materialize constant 0x80 ; const_alias: k1 ; defs_dbg: t21=v21
-    v23:gpr = const(0x0) ; orig: lir#25 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t23=v23
-    v25:gpr = const(0x0) ; orig: lir#26 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t25=v25
-    v45:gpr = copy v2:gpr ; orig: lir#27 ; sem: ssa copy/move ; defs_dbg: t45=v45
-    v46:gpr = copy v9:gpr ; orig: lir#28 ; sem: ssa copy/move ; defs_dbg: t46=v46
-    v47:gpr = copy v10:gpr ; orig: lir#29 ; sem: ssa copy/move ; defs_dbg: t47=v47
-    term: branch b4 ; uses: [] ; orig: lir#30 ; sem: unconditional jump
+  block b3 [params: v2, v37, v39, v41] (preds: b1): ; insts: 12
+    v9:gpr = const(0x7)
+    v10:gpr = const(0x4)
+    v11:gpr = const(0x1)
+    v13:gpr = const(0x7f)
+    v17:gpr = const(0x7)
+    v19:gpr = const(0x1)
+    v21:gpr = const(0x80)
+    v23:gpr = const(0x0)
+    v25:gpr = const(0x0)
+    v45:gpr = copy v2:gpr
+    v46:gpr = copy v9:gpr
+    v47:gpr = copy v10:gpr
+    term: branch b4 ; uses: []
     succs: b4 [v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] ; count: 1
-  block b4 [params: v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] (preds: b3, b4): ; insts: 16 ; params_dbg: p0=v13, p1=v17, p2=v19, p3=v21, p4=v23, p5=v25, p6=v37, p7=v39, p8=v41, p9=v45, p10=v46, p11=v47
-    bounds_check(1) ; orig: lir#31 ; sem: ensure 1 input byte(s) available
-    v18:gpr = Add v46:gpr, v17:gpr ; orig: lir#32 ; sem: integer addition ; defs_dbg: t18=v18
-    v20:gpr = Sub v47:gpr, v19:gpr ; orig: lir#33 ; sem: integer subtraction ; defs_dbg: t20=v20
-    v12:gpr = read_bytes(1) ; orig: lir#34 ; sem: consume 1 input byte(s) ; defs_dbg: t12=v12
-    v26:gpr = CmpNe v20:gpr, v25:gpr ; orig: lir#35 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t26=v26
-    v14:gpr = And v12:gpr, v13:gpr ; orig: lir#36 ; sem: bitwise and ; defs_dbg: t14=v14
-    v22:gpr = And v12:gpr, v21:gpr ; orig: lir#37 ; sem: bitwise and ; defs_dbg: t22=v22
-    v15:gpr = Shl v14:gpr, v46:gpr/hw1 ; orig: lir#38 ; sem: logical shift left ; defs_dbg: t15=v15
-    v24:gpr = CmpNe v22:gpr, v23:gpr ; orig: lir#39 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t24=v24
-    v16:gpr = Or v45:gpr, v15:gpr ; orig: lir#40 ; sem: bitwise or ; defs_dbg: t16=v16
-    v27:gpr = And v24:gpr, v26:gpr ; orig: lir#41 ; sem: bitwise and ; defs_dbg: t27=v27
-    v45:gpr = copy v16:gpr ; orig: lir#42 ; sem: ssa copy/move ; defs_dbg: t45=v45
-    v46:gpr = copy v18:gpr ; orig: lir#43 ; sem: ssa copy/move ; defs_dbg: t46=v46
-    v47:gpr = copy v20:gpr ; orig: lir#44 ; sem: ssa copy/move ; defs_dbg: t47=v47
-    v48:gpr = copy v14:gpr ; orig: lir#45 ; sem: ssa copy/move ; defs_dbg: t48=v48
-    v49:gpr = copy v24:gpr ; orig: lir#46 ; sem: ssa copy/move ; defs_dbg: t49=v49
-    term: branch_if v27 -> b4, fallthrough b5 ; uses: [v27] ; orig: lir#47 ; sem: branch when condition is non-zero
+  block b4 [params: v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] (preds: b3, b4): ; insts: 16
+    bounds_check(1)
+    v18:gpr = Add v46:gpr, v17:gpr
+    v20:gpr = Sub v47:gpr, v19:gpr
+    v12:gpr = read_bytes(1)
+    v26:gpr = CmpNe v20:gpr, v25:gpr
+    v14:gpr = And v12:gpr, v13:gpr
+    v22:gpr = And v12:gpr, v21:gpr
+    v15:gpr = Shl v14:gpr, v46:gpr/hw1
+    v24:gpr = CmpNe v22:gpr, v23:gpr
+    v16:gpr = Or v45:gpr, v15:gpr
+    v27:gpr = And v24:gpr, v26:gpr
+    v45:gpr = copy v16:gpr
+    v46:gpr = copy v18:gpr
+    v47:gpr = copy v20:gpr
+    v48:gpr = copy v14:gpr
+    v49:gpr = copy v24:gpr
+    term: branch_if v27 -> b4, fallthrough b5 ; uses: [v27]
     succs: b4 [v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] b5 [v37, v39, v41, v45, v49] ; count: 2
-  block b5 [params: v37, v39, v41, v45, v49] (preds: b4): ; insts: 2 ; params_dbg: p0=v37, p1=v39, p2=v41, p3=v45, p4=v49
-    v33:gpr = copy v45:gpr ; orig: lir#48 ; sem: ssa copy/move ; defs_dbg: t33=v33
-    v36:gpr = copy v49:gpr ; orig: lir#49 ; sem: ssa copy/move ; defs_dbg: t36=v36
-    term: branch b6 ; uses: [] ; orig: lir#50 ; sem: unconditional jump
+  block b5 [params: v37, v39, v41, v45, v49] (preds: b4): ; insts: 2
+    v33:gpr = copy v45:gpr
+    v36:gpr = copy v49:gpr
+    term: branch b6 ; uses: []
     succs: b6 [v33, v36, v37, v39, v41] ; count: 1
-  block b6 [params: v33, v36, v37, v39, v41] (preds: b2, b5): ; insts: 2 ; params_dbg: p0=v33, p1=v36, p2=v37, p3=v39, p4=v41
-    v38:gpr = CmpNe v36:gpr, v37:gpr ; orig: lir#51 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t38=v38
-    v40:gpr = Shr v33:gpr, v39:gpr/hw1 ; orig: lir#52 ; sem: logical shift right ; defs_dbg: t40=v40
-    term: branch_if_zero v38 -> b8, fallthrough b7 ; uses: [v38] ; orig: lir#53 ; sem: branch when condition is zero
+  block b6 [params: v33, v36, v37, v39, v41] (preds: b2, b5): ; insts: 2
+    v38:gpr = CmpNe v36:gpr, v37:gpr
+    v40:gpr = Shr v33:gpr, v39:gpr/hw1
+    term: branch_if_zero v38 -> b8, fallthrough b7 ; uses: [v38]
     succs: b8 [v33, v40, v41] b7 ; count: 2
   block b7 (preds: b6): ; insts: 0
-    term: branch b9 ; uses: [] ; orig: lir#54 ; sem: unconditional jump
+    term: branch b9 ; uses: []
     succs: b9 ; count: 1
-  block b8 [params: v33, v40, v41] (preds: b6): ; insts: 0 ; params_dbg: p0=v33, p1=v40, p2=v41
-    term: branch b10 ; uses: [] ; orig: lir#55 ; sem: unconditional jump
+  block b8 [params: v33, v40, v41] (preds: b6): ; insts: 0
+    term: branch b10 ; uses: []
     succs: b10 [v33, v40, v41] ; count: 1
   block b9 (preds: b7): ; insts: 0
-    term: error_exit(InvalidVarint) ; uses: [] ; orig: lir#56 ; sem: terminate with error
+    term: error_exit(InvalidVarint) ; uses: []
     succs: (none)
-  block b10 [params: v33, v40, v41] (preds: b8): ; insts: 1 ; params_dbg: p0=v33, p1=v40, p2=v41
-    v42:gpr = CmpNe v40:gpr, v41:gpr ; orig: lir#57 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t42=v42
-    term: branch_if_zero v42 -> b12, fallthrough b11 ; uses: [v42] ; orig: lir#58 ; sem: branch when condition is zero
+  block b10 [params: v33, v40, v41] (preds: b8): ; insts: 1
+    v42:gpr = CmpNe v40:gpr, v41:gpr
+    term: branch_if_zero v42 -> b12, fallthrough b11 ; uses: [v42]
     succs: b12 [v33] b11 ; count: 2
   block b11 (preds: b10): ; insts: 0
-    term: branch b13 ; uses: [] ; orig: lir#59 ; sem: unconditional jump
+    term: branch b13 ; uses: []
     succs: b13 ; count: 1
-  block b12 [params: v33] (preds: b10): ; insts: 0 ; params_dbg: p0=v33
-    term: branch b14 ; uses: [] ; orig: lir#60 ; sem: unconditional jump
+  block b12 [params: v33] (preds: b10): ; insts: 0
+    term: branch b14 ; uses: []
     succs: b14 [v33] ; count: 1
   block b13 (preds: b11): ; insts: 0
-    term: error_exit(NumberOutOfRange) ; uses: [] ; orig: lir#61 ; sem: terminate with error
+    term: error_exit(NumberOutOfRange) ; uses: []
     succs: (none)
-  block b14 [params: v33] (preds: b12): ; insts: 1 ; params_dbg: p0=v33
-    store([0:W4]) v33:gpr ; orig: lir#62 ; sem: write output field at +0 (W4)
-    term: return ; uses: [] ; orig: lir#63 ; sem: finish function
+  block b14 [params: v33] (preds: b12): ; insts: 1
+    store([0:W4]) v33:gpr
+    term: return ; uses: []
     succs: (none)
 }

--- a/kajit/tests/snapshots/mir_text_regression__mir_text_regression__postcard_u32_v0_x86_64_human.snap
+++ b/kajit/tests/snapshots/mir_text_regression__mir_text_regression__postcard_u32_v0_x86_64_human.snap
@@ -1,0 +1,113 @@
+---
+source: kajit/tests/mir_text_regression.rs
+expression: "format!(\"{}\", program.human())"
+---
+ra_func @0 (entry: b0) ; consts: k0=0x7f, k1=0x80, k2=0x0, k3=0x20, k4=0x4, k5=0x7, k6=0x1
+  block b0: ; insts: 11
+    bounds_check(1) ; orig: lir#0 ; sem: ensure 1 input byte(s) available
+    v1:gpr = const(0x7f) ; orig: lir#1 ; sem: materialize constant 0x7f ; const_alias: k0 ; defs_dbg: t1=v1
+    v3:gpr = const(0x80) ; orig: lir#2 ; sem: materialize constant 0x80 ; const_alias: k1 ; defs_dbg: t3=v3
+    v5:gpr = const(0x0) ; orig: lir#3 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t5=v5
+    v37:gpr = const(0x0) ; orig: lir#4 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t37=v37
+    v39:gpr = const(0x20) ; orig: lir#5 ; sem: materialize constant 0x20 ; const_alias: k3 ; defs_dbg: t39=v39
+    v41:gpr = const(0x0) ; orig: lir#6 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t41=v41
+    v0:gpr = read_bytes(1) ; orig: lir#7 ; sem: consume 1 input byte(s) ; defs_dbg: t0=v0
+    v2:gpr = And v0:gpr, v1:gpr ; orig: lir#8 ; sem: bitwise and ; defs_dbg: t2=v2
+    v4:gpr = And v0:gpr, v3:gpr ; orig: lir#9 ; sem: bitwise and ; defs_dbg: t4=v4
+    v6:gpr = CmpNe v4:gpr, v5:gpr ; orig: lir#10 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t6=v6
+    term: branch_if_zero v6 -> b2, fallthrough b1 ; uses: [v6] ; orig: lir#11 ; sem: branch when condition is zero
+    succs: b2 [v2, v37, v39, v41] b1 [v2, v37, v39, v41] ; count: 2
+
+  block b1 [params: v2, v37, v39, v41] (preds: b0): ; insts: 0 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
+    term: branch b3 ; uses: [] ; orig: lir#12 ; sem: unconditional jump
+    succs: b3 [v2, v37, v39, v41] ; count: 1
+
+  block b2 [params: v2, v37, v39, v41] (preds: b0): ; insts: 4 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
+    v7:gpr = const(0x4) ; orig: lir#13 ; sem: materialize constant 0x4 ; const_alias: k4 ; defs_dbg: t7=v7
+    v8:gpr = const(0x0) ; orig: lir#14 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t8=v8
+    v33:gpr = copy v2:gpr ; orig: lir#15 ; sem: ssa copy/move ; defs_dbg: t33=v33
+    v36:gpr = copy v8:gpr ; orig: lir#16 ; sem: ssa copy/move ; defs_dbg: t36=v36
+    term: branch b6 ; uses: [] ; orig: lir#17 ; sem: unconditional jump
+    succs: b6 [v33, v8, v37, v39, v41] ; count: 1
+
+  block b3 [params: v2, v37, v39, v41] (preds: b1): ; insts: 12 ; params_dbg: p0=v2, p1=v37, p2=v39, p3=v41
+    v9:gpr = const(0x7) ; orig: lir#18 ; sem: materialize constant 0x7 ; const_alias: k5 ; defs_dbg: t9=v9
+    v10:gpr = const(0x4) ; orig: lir#19 ; sem: materialize constant 0x4 ; const_alias: k4 ; defs_dbg: t10=v10
+    v11:gpr = const(0x1) ; orig: lir#20 ; sem: materialize constant 0x1 ; const_alias: k6 ; defs_dbg: t11=v11
+    v13:gpr = const(0x7f) ; orig: lir#21 ; sem: materialize constant 0x7f ; const_alias: k0 ; defs_dbg: t13=v13
+    v17:gpr = const(0x7) ; orig: lir#22 ; sem: materialize constant 0x7 ; const_alias: k5 ; defs_dbg: t17=v17
+    v19:gpr = const(0x1) ; orig: lir#23 ; sem: materialize constant 0x1 ; const_alias: k6 ; defs_dbg: t19=v19
+    v21:gpr = const(0x80) ; orig: lir#24 ; sem: materialize constant 0x80 ; const_alias: k1 ; defs_dbg: t21=v21
+    v23:gpr = const(0x0) ; orig: lir#25 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t23=v23
+    v25:gpr = const(0x0) ; orig: lir#26 ; sem: materialize constant 0x0 ; const_alias: k2 ; defs_dbg: t25=v25
+    v45:gpr = copy v2:gpr ; orig: lir#27 ; sem: ssa copy/move ; defs_dbg: t45=v45
+    v46:gpr = copy v9:gpr ; orig: lir#28 ; sem: ssa copy/move ; defs_dbg: t46=v46
+    v47:gpr = copy v10:gpr ; orig: lir#29 ; sem: ssa copy/move ; defs_dbg: t47=v47
+    term: branch b4 ; uses: [] ; orig: lir#30 ; sem: unconditional jump
+    succs: b4 [v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] ; count: 1
+
+  block b4 [params: v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] (preds: b3, b4): ; insts: 16 ; params_dbg: p0=v13, p1=v17, p2=v19, p3=v21, p4=v23, p5=v25, p6=v37, p7=v39, p8=v41, p9=v45, p10=v46, p11=v47
+    bounds_check(1) ; orig: lir#31 ; sem: ensure 1 input byte(s) available
+    v18:gpr = Add v46:gpr, v17:gpr ; orig: lir#32 ; sem: integer addition ; defs_dbg: t18=v18
+    v20:gpr = Sub v47:gpr, v19:gpr ; orig: lir#33 ; sem: integer subtraction ; defs_dbg: t20=v20
+    v12:gpr = read_bytes(1) ; orig: lir#34 ; sem: consume 1 input byte(s) ; defs_dbg: t12=v12
+    v26:gpr = CmpNe v20:gpr, v25:gpr ; orig: lir#35 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t26=v26
+    v14:gpr = And v12:gpr, v13:gpr ; orig: lir#36 ; sem: bitwise and ; defs_dbg: t14=v14
+    v22:gpr = And v12:gpr, v21:gpr ; orig: lir#37 ; sem: bitwise and ; defs_dbg: t22=v22
+    v15:gpr = Shl v14:gpr, v46:gpr/hw1 ; orig: lir#38 ; sem: logical shift left ; defs_dbg: t15=v15
+    v24:gpr = CmpNe v22:gpr, v23:gpr ; orig: lir#39 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t24=v24
+    v16:gpr = Or v45:gpr, v15:gpr ; orig: lir#40 ; sem: bitwise or ; defs_dbg: t16=v16
+    v27:gpr = And v24:gpr, v26:gpr ; orig: lir#41 ; sem: bitwise and ; defs_dbg: t27=v27
+    v45:gpr = copy v16:gpr ; orig: lir#42 ; sem: ssa copy/move ; defs_dbg: t45=v45
+    v46:gpr = copy v18:gpr ; orig: lir#43 ; sem: ssa copy/move ; defs_dbg: t46=v46
+    v47:gpr = copy v20:gpr ; orig: lir#44 ; sem: ssa copy/move ; defs_dbg: t47=v47
+    v48:gpr = copy v14:gpr ; orig: lir#45 ; sem: ssa copy/move ; defs_dbg: t48=v48
+    v49:gpr = copy v24:gpr ; orig: lir#46 ; sem: ssa copy/move ; defs_dbg: t49=v49
+    term: branch_if v27 -> b4, fallthrough b5 ; uses: [v27] ; orig: lir#47 ; sem: branch when condition is non-zero
+    succs: b4 [v13, v17, v19, v21, v23, v25, v37, v39, v41, v45, v46, v47] b5 [v37, v39, v41, v45, v49] ; count: 2
+
+  block b5 [params: v37, v39, v41, v45, v49] (preds: b4): ; insts: 2 ; params_dbg: p0=v37, p1=v39, p2=v41, p3=v45, p4=v49
+    v33:gpr = copy v45:gpr ; orig: lir#48 ; sem: ssa copy/move ; defs_dbg: t33=v33
+    v36:gpr = copy v49:gpr ; orig: lir#49 ; sem: ssa copy/move ; defs_dbg: t36=v36
+    term: branch b6 ; uses: [] ; orig: lir#50 ; sem: unconditional jump
+    succs: b6 [v33, v36, v37, v39, v41] ; count: 1
+
+  block b6 [params: v33, v36, v37, v39, v41] (preds: b2, b5): ; insts: 2 ; params_dbg: p0=v33, p1=v36, p2=v37, p3=v39, p4=v41
+    v38:gpr = CmpNe v36:gpr, v37:gpr ; orig: lir#51 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t38=v38
+    v40:gpr = Shr v33:gpr, v39:gpr/hw1 ; orig: lir#52 ; sem: logical shift right ; defs_dbg: t40=v40
+    term: branch_if_zero v38 -> b8, fallthrough b7 ; uses: [v38] ; orig: lir#53 ; sem: branch when condition is zero
+    succs: b8 [v33, v40, v41] b7 ; count: 2
+
+  block b7 (preds: b6): ; insts: 0
+    term: branch b9 ; uses: [] ; orig: lir#54 ; sem: unconditional jump
+    succs: b9 ; count: 1
+
+  block b8 [params: v33, v40, v41] (preds: b6): ; insts: 0 ; params_dbg: p0=v33, p1=v40, p2=v41
+    term: branch b10 ; uses: [] ; orig: lir#55 ; sem: unconditional jump
+    succs: b10 [v33, v40, v41] ; count: 1
+
+  block b9 (preds: b7): ; insts: 0
+    term: error_exit(InvalidVarint) ; uses: [] ; orig: lir#56 ; sem: terminate with error
+    succs: (none)
+
+  block b10 [params: v33, v40, v41] (preds: b8): ; insts: 1 ; params_dbg: p0=v33, p1=v40, p2=v41
+    v42:gpr = CmpNe v40:gpr, v41:gpr ; orig: lir#57 ; sem: compare not-equal (produces 0/1) ; defs_dbg: t42=v42
+    term: branch_if_zero v42 -> b12, fallthrough b11 ; uses: [v42] ; orig: lir#58 ; sem: branch when condition is zero
+    succs: b12 [v33] b11 ; count: 2
+
+  block b11 (preds: b10): ; insts: 0
+    term: branch b13 ; uses: [] ; orig: lir#59 ; sem: unconditional jump
+    succs: b13 ; count: 1
+
+  block b12 [params: v33] (preds: b10): ; insts: 0 ; params_dbg: p0=v33
+    term: branch b14 ; uses: [] ; orig: lir#60 ; sem: unconditional jump
+    succs: b14 [v33] ; count: 1
+
+  block b13 (preds: b11): ; insts: 0
+    term: error_exit(NumberOutOfRange) ; uses: [] ; orig: lir#61 ; sem: terminate with error
+    succs: (none)
+
+  block b14 [params: v33] (preds: b12): ; insts: 1 ; params_dbg: p0=v33
+    store([0:W4]) v33:gpr ; orig: lir#62 ; sem: write output field at +0 (W4)
+    term: return ; uses: [] ; orig: lir#63 ; sem: finish function
+    succs: (none)


### PR DESCRIPTION
## Summary
- keep canonical RA-MIR display as the parseable, stable source of truth
- add a separate human renderer (`program.human()` / `format!("{ra:#}")`) for debugging
- #131: semantic hints live in human output (`; sem: ...`)
- #132: debug names for temps/block params in human output
- #133: provenance comments in human output (`; orig: lir#...`)
- #134: const aliasing in human output (`consts:` table + `const_alias` tags)
- add a human-render snapshot test for the postcard u32 regression fixture
- regenerate x86_64 RA-MIR snapshot and manually refresh in-file fixture from that snapshot

## Validation
- `cargo nextest run -p kajit-mir -p kajit-mir-text`
- `INSTA_UPDATE=always cargo nextest run -p kajit --target x86_64-apple-darwin -E 'test(ra_mir_postcard::scalar_u32_v0) | test(postcard_u32_human_ra_mir_snapshot) | test(postcard_u32_single_byte_varint) | test(postcard_u32_multi_byte_varint)'`
- `cargo nextest run -p kajit --target x86_64-apple-darwin -E 'test(ra_mir_postcard::scalar_u32_v0) | test(postcard_u32_human_ra_mir_snapshot) | test(postcard_u32_single_byte_varint) | test(postcard_u32_multi_byte_varint)'`

## Links
- Closes #131
- Closes #132
- Closes #133
- Closes #134

## Notes
- Human renderer intentionally avoids CFG rewrites (no trampoline collapsing) to avoid hiding control-flow bugs before #135.
