### PR TITLE
Re-enable default compile passes and add per-pass KAJIT_OPTS registry

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -67,6 +67,12 @@ Supported options:
 - `all_opts`: default RVSDG optimization passes before linearization
 - `regalloc`: regalloc edit application during backend emission
 
+Per-pass options:
+- `pass.bounds_check_coalescing`
+- `pass.theta_loop_invariant_hoist`
+- `pass.inline_apply`
+- `pass.dead_code_elimination`
+
 Examples:
 ```bash
 # disable optimization passes
@@ -77,6 +83,14 @@ KAJIT_OPTS='-regalloc' cargo nextest run -p kajit <test_filter>
 
 # disable both
 KAJIT_OPTS='-all_opts,-regalloc' cargo nextest run -p kajit <test_filter>
+
+# disable one specific default pass
+KAJIT_OPTS='-pass.inline_apply' cargo nextest run -p kajit <test_filter>
+```
+
+Show built-in help:
+```bash
+KAJIT_OPTS=help cargo nextest run -p kajit <test_filter>
 ```
 
 On Apple Silicon, combine with x86_64 Rosetta validation:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -617,6 +617,19 @@ r[compiler.opts.composition]
 Multiple option tokens compose left-to-right; for repeated option names, the
 last token wins.
 
+r[compiler.opts.pass-registry]
+Default IR passes are individually addressable by stable option names and
+descriptions. Each pass can be toggled independently through `KAJIT_OPTS`.
+
+r[compiler.opts.help]
+When `KAJIT_OPTS=help`, compilation fails fast with a deterministic help
+message describing syntax, top-level options, and per-pass toggle names.
+
+r[compiler.opts.api]
+Pipeline option enable/disable controls are available through a public API so
+callers can configure compile behavior without relying on process environment
+variables.
+
 r[compiler.opts.invalid]
 On invalid `KAJIT_OPTS` content, compilation fails with a clear error that
 identifies the offending token and lists supported option names.

--- a/kajit-ir/src/ir_passes.rs
+++ b/kajit-ir/src/ir_passes.rs
@@ -118,14 +118,18 @@ impl UseLists {
 
 // r[impl ir.passes]
 pub fn run_default_passes(func: &mut IrFunc) {
-    bounds_check_coalescing_pass(func);
-    debug_verify(func, "bounds_check_coalescing_pass");
-    hoist_theta_loop_invariant_setup_pass(func);
-    debug_verify(func, "hoist_theta_loop_invariant_setup_pass");
-    inline_apply_pass(func);
-    debug_verify(func, "inline_apply_pass");
-    dead_code_elimination_pass(func);
-    debug_verify(func, "dead_code_elimination_pass");
+    run_default_passes_with_filter(func, |_| true);
+}
+
+pub fn run_default_passes_with_filter<F>(func: &mut IrFunc, mut enabled: F)
+where
+    F: FnMut(DefaultPassSpec) -> bool,
+{
+    for pass in default_pass_registry() {
+        if enabled(*pass) {
+            pass.run(func);
+        }
+    }
 }
 
 #[cfg(debug_assertions)]
@@ -137,6 +141,66 @@ fn debug_verify(func: &IrFunc, pass_name: &str) {
 
 #[cfg(not(debug_assertions))]
 fn debug_verify(_func: &IrFunc, _pass_name: &str) {}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DefaultPassSpec {
+    pub name: &'static str,
+    pub description: &'static str,
+    run: fn(&mut IrFunc),
+}
+
+impl DefaultPassSpec {
+    pub fn run(self, func: &mut IrFunc) {
+        (self.run)(func);
+    }
+}
+
+fn run_bounds_check_coalescing_pass(func: &mut IrFunc) {
+    bounds_check_coalescing_pass(func);
+    debug_verify(func, "bounds_check_coalescing_pass");
+}
+
+fn run_hoist_theta_loop_invariant_setup_pass(func: &mut IrFunc) {
+    hoist_theta_loop_invariant_setup_pass(func);
+    debug_verify(func, "hoist_theta_loop_invariant_setup_pass");
+}
+
+fn run_inline_apply_pass(func: &mut IrFunc) {
+    inline_apply_pass(func);
+    debug_verify(func, "inline_apply_pass");
+}
+
+fn run_dead_code_elimination_pass(func: &mut IrFunc) {
+    dead_code_elimination_pass(func);
+    debug_verify(func, "dead_code_elimination_pass");
+}
+
+const DEFAULT_PASS_REGISTRY: [DefaultPassSpec; 4] = [
+    DefaultPassSpec {
+        name: "bounds_check_coalescing",
+        description: "Coalesce redundant BoundsCheck chains in cursor pipelines.",
+        run: run_bounds_check_coalescing_pass,
+    },
+    DefaultPassSpec {
+        name: "theta_loop_invariant_hoist",
+        description: "Hoist loop-invariant setup out of theta loop bodies when safe.",
+        run: run_hoist_theta_loop_invariant_setup_pass,
+    },
+    DefaultPassSpec {
+        name: "inline_apply",
+        description: "Inline apply/lambda calls under size and use-site thresholds.",
+        run: run_inline_apply_pass,
+    },
+    DefaultPassSpec {
+        name: "dead_code_elimination",
+        description: "Remove dead nodes and unreachable regions after shaping passes.",
+        run: run_dead_code_elimination_pass,
+    },
+];
+
+pub fn default_pass_registry() -> &'static [DefaultPassSpec] {
+    &DEFAULT_PASS_REGISTRY
+}
 
 // r[impl ir.passes.planned]
 fn bounds_check_coalescing_pass(func: &mut IrFunc) {

--- a/kajit/src/compiler.rs
+++ b/kajit/src/compiler.rs
@@ -44,6 +44,8 @@ impl CompiledDecoder {
     }
 }
 
+pub(crate) const DEFAULT_PRE_LINEARIZATION_PASSES_ENABLED: bool = true;
+
 // r[impl compiler.walk]
 // r[impl compiler.recursive]
 // r[impl compiler.recursive.one-func-per-shape]
@@ -648,28 +650,42 @@ impl<'a> IrShapeLowerer<'a> {
 /// Compile a deserializer through RVSDG + linearization + backend adapter.
 pub fn compile_decoder(shape: &'static Shape, decoder: &dyn Decoder) -> CompiledDecoder {
     let pipeline_opts = PipelineOptions::from_env();
+    compile_decoder_with_options(shape, decoder, &pipeline_opts)
+}
+
+// r[impl compiler.opts.api]
+pub fn compile_decoder_with_options(
+    shape: &'static Shape,
+    decoder: &dyn Decoder,
+    pipeline_opts: &PipelineOptions,
+) -> CompiledDecoder {
     let mut func = build_decoder_ir(shape, decoder);
-    // r[impl compiler.opts.all-opts]
-    if pipeline_opts.resolve_all_opts(false) {
-        crate::ir_passes::run_default_passes(&mut func);
-    }
+    run_configured_default_passes(&mut func, pipeline_opts);
     let linear = crate::linearize::linearize(&mut func);
     compile_linear_ir_decoder_with_options(
         &linear,
         decoder.supports_trusted_utf8_input(),
-        pipeline_opts,
+        pipeline_opts.clone(),
     )
 }
 
 // r[impl ir.regalloc.regressions]
 /// Build IR + linear form and run regalloc over it, returning total edit count.
+///
+/// This is a full-pipeline diagnostic helper, not a lightweight metric.
 pub fn regalloc_edit_count(shape: &'static Shape, ir_decoder: &dyn Decoder) -> usize {
     let pipeline_opts = PipelineOptions::from_env();
+    regalloc_edit_count_with_options(shape, ir_decoder, &pipeline_opts)
+}
+
+// r[impl compiler.opts.api]
+pub fn regalloc_edit_count_with_options(
+    shape: &'static Shape,
+    ir_decoder: &dyn Decoder,
+    pipeline_opts: &PipelineOptions,
+) -> usize {
     let mut func = build_decoder_ir(shape, ir_decoder);
-    // r[impl compiler.opts.all-opts]
-    if pipeline_opts.resolve_all_opts(true) {
-        crate::ir_passes::run_default_passes(&mut func);
-    }
+    run_configured_default_passes(&mut func, pipeline_opts);
     let linear = crate::linearize::linearize(&mut func);
     let alloc = crate::regalloc_engine::allocate_linear_ir(&linear)
         .unwrap_or_else(|err| panic!("regalloc2 allocation failed while counting edits: {err}"));
@@ -716,15 +732,25 @@ pub(crate) fn build_decoder_ir(
     builder.finish()
 }
 
-// r[impl compiler.opts.all-opts]
-pub(crate) fn should_run_default_passes(default_enabled: bool) -> bool {
-    PipelineOptions::from_env().resolve_all_opts(default_enabled)
+pub(crate) fn run_default_passes_from_env(func: &mut crate::ir::IrFunc) {
+    let pipeline_opts = PipelineOptions::from_env();
+    run_configured_default_passes(func, &pipeline_opts);
+}
+
+fn run_configured_default_passes(func: &mut crate::ir::IrFunc, pipeline_opts: &PipelineOptions) {
+    // r[impl compiler.opts.all-opts]
+    if !pipeline_opts.resolve_all_opts(DEFAULT_PRE_LINEARIZATION_PASSES_ENABLED) {
+        return;
+    }
+    crate::ir_passes::run_default_passes_with_filter(func, |pass| {
+        pipeline_opts.resolve_pass(pass.name, true)
+    });
 }
 
 // r[impl compiler.opts.regalloc]
 fn maybe_disable_regalloc_edits(
     alloc: &mut crate::regalloc_engine::AllocatedProgram,
-    pipeline_opts: PipelineOptions,
+    pipeline_opts: &PipelineOptions,
 ) {
     if pipeline_opts.resolve_regalloc(true) {
         return;
@@ -758,7 +784,7 @@ fn compile_linear_ir_decoder_with_options(
     // Run regalloc2 over RA-MIR and thread allocation artifacts into emission.
     let mut regalloc_alloc = crate::regalloc_engine::allocate_program(&ra_mir)
         .unwrap_or_else(|err| panic!("regalloc2 allocation failed: {err}"));
-    maybe_disable_regalloc_edits(&mut regalloc_alloc, pipeline_opts);
+    maybe_disable_regalloc_edits(&mut regalloc_alloc, &pipeline_opts);
 
     let crate::ir_backend::LinearBackendResult { buf, entry } =
         crate::ir_backend::compile_linear_ir_with_alloc(ir, &ra_mir, &regalloc_alloc);
@@ -799,7 +825,7 @@ fn compile_linear_ir_decoder_with_options(
 pub fn compile_ra_program_decoder(program: &crate::regalloc_mir::RaProgram) -> CompiledDecoder {
     let mut alloc = crate::regalloc_engine::allocate_program(program)
         .unwrap_or_else(|err| panic!("regalloc2 allocation failed: {err}"));
-    maybe_disable_regalloc_edits(&mut alloc, PipelineOptions::from_env());
+    maybe_disable_regalloc_edits(&mut alloc, &PipelineOptions::from_env());
 
     let crate::ir_backend::LinearBackendResult { buf, entry } =
         crate::ir_backend::compile_ra_program(program, &alloc);

--- a/kajit/src/ir_passes.rs
+++ b/kajit/src/ir_passes.rs
@@ -1,1 +1,3 @@
-pub use kajit_ir::run_default_passes;
+pub use kajit_ir::{
+    DefaultPassSpec, default_pass_registry, run_default_passes, run_default_passes_with_filter,
+};

--- a/kajit/src/lib.rs
+++ b/kajit/src/lib.rs
@@ -20,7 +20,7 @@ pub mod json;
 pub mod json_intrinsics;
 pub mod linearize;
 pub mod malum;
-mod pipeline_opts;
+pub mod pipeline_opts;
 pub mod postcard;
 mod pow10tab;
 pub mod recipe;
@@ -31,6 +31,7 @@ pub mod solver;
 
 use compiler::CompiledDecoder;
 use context::{DeserContext, ErrorCode};
+pub use pipeline_opts::PipelineOptions;
 
 /// Compile a deserializer for the given shape and format.
 pub fn compile_decoder(
@@ -40,9 +41,27 @@ pub fn compile_decoder(
     compiler::compile_decoder(shape, decoder)
 }
 
+/// Compile a deserializer with explicit pipeline options.
+pub fn compile_decoder_with_options(
+    shape: &'static facet::Shape,
+    decoder: &dyn format::Decoder,
+    pipeline_opts: &PipelineOptions,
+) -> CompiledDecoder {
+    compiler::compile_decoder_with_options(shape, decoder, pipeline_opts)
+}
+
 /// Return the number of regalloc edit instructions produced by IR lowering.
 pub fn regalloc_edit_count<F: format::Decoder>(shape: &'static facet::Shape, decoder: &F) -> usize {
     compiler::regalloc_edit_count(shape, decoder)
+}
+
+/// Return the number of regalloc edit instructions produced by IR lowering with explicit options.
+pub fn regalloc_edit_count_with_options<F: format::Decoder>(
+    shape: &'static facet::Shape,
+    decoder: &F,
+    pipeline_opts: &PipelineOptions,
+) -> usize {
+    compiler::regalloc_edit_count_with_options(shape, decoder, pipeline_opts)
 }
 
 /// Compile a deserializer from already-linearized IR.
@@ -67,8 +86,8 @@ pub fn compile_decoder_from_ir_text(
     with_passes: bool,
 ) -> CompiledDecoder {
     let mut func = ir_parse::parse_ir(ir_text, shape, registry).expect("IR text should parse");
-    if with_passes && compiler::should_run_default_passes(true) {
-        ir_passes::run_default_passes(&mut func);
+    if with_passes {
+        compiler::run_default_passes_from_env(&mut func);
     }
     let linear = linearize::linearize(&mut func);
     compiler::compile_linear_ir_decoder(&linear, false)
@@ -101,9 +120,7 @@ pub fn debug_ir_and_ra_mir_text(
     ir_decoder: &dyn format::Decoder,
 ) -> (String, String) {
     let mut func = compiler::build_decoder_ir(shape, ir_decoder);
-    if compiler::should_run_default_passes(true) {
-        ir_passes::run_default_passes(&mut func);
-    }
+    compiler::run_default_passes_from_env(&mut func);
     let ir_text = scrub_volatile_intrinsic_addrs(&format!("{func}"));
     let linear = linearize::linearize(&mut func);
     let ra = regalloc_mir::lower_linear_ir(&linear);
@@ -119,9 +136,7 @@ pub fn debug_ra_mir_human_text(
     ir_decoder: &dyn format::Decoder,
 ) -> String {
     let mut func = compiler::build_decoder_ir(shape, ir_decoder);
-    if compiler::should_run_default_passes(true) {
-        ir_passes::run_default_passes(&mut func);
-    }
+    compiler::run_default_passes_from_env(&mut func);
     let linear = linearize::linearize(&mut func);
     let ra = regalloc_mir::lower_linear_ir(&linear);
     scrub_volatile_intrinsic_addrs(&format!("{}", ra.human()))
@@ -135,9 +150,7 @@ pub fn debug_linear_ir_text(
     ir_decoder: &dyn format::Decoder,
 ) -> String {
     let mut func = compiler::build_decoder_ir(shape, ir_decoder);
-    if compiler::should_run_default_passes(true) {
-        ir_passes::run_default_passes(&mut func);
-    }
+    compiler::run_default_passes_from_env(&mut func);
     let linear = linearize::linearize(&mut func);
     scrub_volatile_intrinsic_addrs(&format!("{linear}"))
 }

--- a/kajit/src/pipeline_opts.rs
+++ b/kajit/src/pipeline_opts.rs
@@ -1,19 +1,14 @@
-const KAJIT_OPTS_ENV: &str = "KAJIT_OPTS";
-const KNOWN_OPTIONS: &[&str] = &["all_opts", "regalloc"];
+use std::collections::BTreeMap;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+const KAJIT_OPTS_ENV: &str = "KAJIT_OPTS";
+const KAJIT_OPTS_HELP: &str = "help";
+const PASS_OPTION_PREFIX: &str = "pass.";
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct PipelineOptions {
     pub all_opts: Option<bool>,
     pub regalloc: Option<bool>,
-}
-
-impl Default for PipelineOptions {
-    fn default() -> Self {
-        Self {
-            all_opts: None,
-            regalloc: None,
-        }
-    }
+    pass_overrides: BTreeMap<String, bool>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,19 +35,24 @@ impl std::error::Error for ParseError {}
 impl PipelineOptions {
     // r[impl compiler.opts]
     // r[impl compiler.opts.defaults]
+    // r[impl compiler.opts.help]
     // r[impl compiler.opts.invalid]
     pub fn from_env() -> Self {
         let Some(raw) = std::env::var_os(KAJIT_OPTS_ENV) else {
             return Self::default();
         };
         let raw = raw.to_string_lossy();
-        if raw.trim().is_empty() {
+        let raw = raw.trim();
+        if raw.is_empty() {
             return Self::default();
         }
-        Self::parse(&raw).unwrap_or_else(|error| {
+        if raw.eq_ignore_ascii_case(KAJIT_OPTS_HELP) {
+            panic!("{}", Self::help_text());
+        }
+        Self::parse(raw).unwrap_or_else(|error| {
             panic!(
-                "invalid {KAJIT_OPTS_ENV}={raw:?}: {error}. Supported options: {}",
-                KNOWN_OPTIONS.join(", ")
+                "invalid {KAJIT_OPTS_ENV}={raw:?}: {error}\n\n{}",
+                Self::help_text()
             )
         })
     }
@@ -76,33 +76,106 @@ impl PipelineOptions {
             if name.is_empty() {
                 return Err(ParseError::new(format!("empty option token in {input:?}")));
             }
-
-            match name {
-                "all_opts" => opts.all_opts = Some(enabled),
-                "regalloc" => opts.regalloc = Some(enabled),
-                other => {
-                    return Err(ParseError::new(format!(
-                        "unknown option {other:?} in {input:?}"
-                    )));
-                }
-            }
+            opts.set_option(name, enabled)?;
         }
 
         Ok(opts)
     }
 
-    pub fn resolve_all_opts(self, default_enabled: bool) -> bool {
+    // r[impl compiler.opts.pass-registry]
+    pub fn set_option(&mut self, name: &str, enabled: bool) -> Result<(), ParseError> {
+        match name {
+            "all_opts" => {
+                self.all_opts = Some(enabled);
+                return Ok(());
+            }
+            "regalloc" => {
+                self.regalloc = Some(enabled);
+                return Ok(());
+            }
+            _ => {}
+        }
+
+        let pass_name = name.strip_prefix(PASS_OPTION_PREFIX).unwrap_or(name);
+        if !is_known_pass(pass_name) {
+            return Err(ParseError::new(format!("unknown option {name:?}")));
+        }
+
+        self.pass_overrides.insert(pass_name.to_owned(), enabled);
+        Ok(())
+    }
+
+    // r[impl compiler.opts.api]
+    pub fn enable_option(&mut self, name: &str) -> Result<(), ParseError> {
+        self.set_option(name, true)
+    }
+
+    // r[impl compiler.opts.api]
+    pub fn disable_option(&mut self, name: &str) -> Result<(), ParseError> {
+        self.set_option(name, false)
+    }
+
+    pub fn resolve_all_opts(&self, default_enabled: bool) -> bool {
         self.all_opts.unwrap_or(default_enabled)
     }
 
-    pub fn resolve_regalloc(self, default_enabled: bool) -> bool {
+    pub fn resolve_regalloc(&self, default_enabled: bool) -> bool {
         self.regalloc.unwrap_or(default_enabled)
     }
+
+    pub fn resolve_pass(&self, pass_name: &str, default_enabled: bool) -> bool {
+        self.pass_overrides
+            .get(pass_name)
+            .copied()
+            .unwrap_or(default_enabled)
+    }
+
+    pub fn help_text() -> String {
+        let mut out = String::new();
+        out.push_str("KAJIT_OPTS usage:\n");
+        out.push_str("  comma-separated tokens, each optionally prefixed with '+' or '-'\n");
+        out.push_str("  examples: -all_opts, +regalloc, -pass.inline_apply\n\n");
+        out.push_str("Top-level options:\n");
+        out.push_str("  all_opts  : enable/disable pre-linearization default passes\n");
+        out.push_str("  regalloc  : enable/disable regalloc edit application\n\n");
+        out.push_str("Per-pass options:\n");
+        for pass in crate::ir_passes::default_pass_registry() {
+            out.push_str(&format!("  pass.{}  : {}\n", pass.name, pass.description));
+        }
+        out.push_str("\nSet KAJIT_OPTS=help to print this message.");
+        out
+    }
+}
+
+fn is_known_pass(name: &str) -> bool {
+    crate::ir_passes::default_pass_registry()
+        .iter()
+        .any(|pass| pass.name == name)
 }
 
 #[cfg(test)]
 mod tests {
-    use super::PipelineOptions;
+    use std::sync::Mutex;
+
+    use super::{KAJIT_OPTS_ENV, PipelineOptions};
+
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_kajit_opts_env(value: Option<&str>, f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+        match value {
+            Some(value) => unsafe {
+                std::env::set_var(KAJIT_OPTS_ENV, value);
+            },
+            None => unsafe {
+                std::env::remove_var(KAJIT_OPTS_ENV);
+            },
+        }
+        f();
+        unsafe {
+            std::env::remove_var(KAJIT_OPTS_ENV);
+        }
+    }
 
     // r[verify compiler.opts.defaults]
     #[test]
@@ -130,6 +203,13 @@ mod tests {
         assert_eq!(got.regalloc, Some(true));
     }
 
+    #[test]
+    fn parse_supports_per_pass_toggles() {
+        let got = PipelineOptions::parse("-pass.inline_apply,+theta_loop_invariant_hoist").unwrap();
+        assert_eq!(got.resolve_pass("inline_apply", true), false);
+        assert_eq!(got.resolve_pass("theta_loop_invariant_hoist", false), true);
+    }
+
     // r[verify compiler.opts.invalid]
     #[test]
     fn parse_rejects_unknown_tokens() {
@@ -141,16 +221,57 @@ mod tests {
     }
 
     #[test]
+    // r[verify compiler.opts.api]
     fn resolve_falls_back_to_callsite_defaults() {
         let got = PipelineOptions::default();
         assert_eq!(got.resolve_all_opts(false), false);
         assert_eq!(got.resolve_regalloc(true), true);
+        assert_eq!(got.resolve_pass("inline_apply", true), true);
     }
 
     #[test]
+    // r[verify compiler.opts.api]
     fn resolve_prefers_explicit_overrides() {
         let got = PipelineOptions::parse("-all_opts,+regalloc").unwrap();
         assert_eq!(got.resolve_all_opts(true), false);
         assert_eq!(got.resolve_regalloc(false), true);
+    }
+
+    #[test]
+    // r[verify compiler.opts]
+    fn from_env_reads_kajit_opts() {
+        with_kajit_opts_env(Some("-regalloc"), || {
+            let got = PipelineOptions::from_env();
+            assert_eq!(got.resolve_regalloc(true), false);
+        });
+    }
+
+    #[test]
+    // r[verify compiler.opts.pass-registry]
+    fn from_env_reads_per_pass_toggles() {
+        with_kajit_opts_env(Some("-pass.inline_apply"), || {
+            let got = PipelineOptions::from_env();
+            assert_eq!(got.resolve_pass("inline_apply", true), false);
+        });
+    }
+
+    #[test]
+    // r[verify compiler.opts.help]
+    fn from_env_help_panics_with_help_text() {
+        with_kajit_opts_env(Some("help"), || {
+            let panic = std::panic::catch_unwind(PipelineOptions::from_env)
+                .expect_err("KAJIT_OPTS=help should panic with usage text");
+            let msg = match panic.downcast::<String>() {
+                Ok(msg) => *msg,
+                Err(panic) => match panic.downcast::<&str>() {
+                    Ok(msg) => (*msg).to_owned(),
+                    Err(_) => "<non-string panic>".to_owned(),
+                },
+            };
+            assert!(
+                msg.contains("KAJIT_OPTS usage"),
+                "unexpected help panic: {msg}"
+            );
+        });
     }
 }


### PR DESCRIPTION
## Summary
- re-enable default pre-linearization passes in `compile_decoder` (aligning compile path with debug/stat paths)
- add a named default-pass registry in `kajit-ir` with descriptions
- add filtered pass execution (`run_default_passes_with_filter`) for per-pass control
- extend `KAJIT_OPTS` to support per-pass toggles (for example `-pass.inline_apply`)
- add `KAJIT_OPTS=help` with a deterministic help message
- expose explicit options API:
  - `PipelineOptions` is public
  - `compile_decoder_with_options(...)`
  - `regalloc_edit_count_with_options(...)`
- route debug/text helper pass application through the same env-driven config path
- document the workflow in `DEVELOP.md` and spec requirements in `docs/spec.md`

Closes #122

## Notes
This intentionally keeps the known JSON failures visible with default passes re-enabled on compile path; CI is expected to stay red until follow-up debugging/fixes.

## Validation
- `cargo fmt`
- `cargo nextest run -p kajit pipeline_opts::tests::` ✅
- `cargo nextest run -p kajit integer_boundaries all_integers all_scalars` ❌
  - fails in known JSON cases with default passes enabled (expected for this step)
