### PR TITLE
Add on-demand per-pass RVSDG dump timeline for corpus

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -93,6 +93,32 @@ Show built-in help:
 KAJIT_OPTS=help cargo nextest run -p kajit <test_filter>
 ```
 
+### On-demand pipeline dumps (without snapshot churn)
+
+Generated corpus tests no longer enforce large IR/RA-MIR/edit snapshots by
+default. Instead, dump pipeline artifacts only when needed:
+
+- `KAJIT_DUMP_STAGES`: comma-separated stage list (`ir`, `linear`, `ra`, `edits`, `opts`, or `all`)
+- `KAJIT_DUMP_FILTER`: optional comma-separated substring filters matched against
+  `"<format>::<case>"` (for example `json::all_scalars`)
+- `KAJIT_DUMP_DIR`: output directory (default: workspace `target/kajit-stage-dumps`)
+- `KAJIT_ASSERT_CODEGEN_SNAPSHOTS=1`: opt back into legacy snapshot assertions
+
+Example (focus on theta-loop-invariant-hoist investigation):
+```bash
+KAJIT_OPTS='+all_opts,+regalloc,-pass.theta_loop_invariant_hoist' \
+KAJIT_DUMP_STAGES='ir,linear,ra,edits' \
+KAJIT_DUMP_FILTER='json::all_scalars' \
+cargo nextest run -p kajit --test corpus -E 'test(=json::all_scalars)'
+```
+
+To dump RVSDG between every optimization pass (plus `initial`):
+```bash
+KAJIT_DUMP_STAGES='opts' \
+KAJIT_DUMP_FILTER='json::all_scalars' \
+cargo nextest run -p kajit --test corpus -E 'test(=rvsdg_json::all_scalars)'
+```
+
 On Apple Silicon, combine with x86_64 Rosetta validation:
 ```bash
 KAJIT_OPTS='-regalloc' cargo xtask test-x86_64 --full -- \

--- a/kajit/src/compiler.rs
+++ b/kajit/src/compiler.rs
@@ -737,14 +737,32 @@ pub(crate) fn run_default_passes_from_env(func: &mut crate::ir::IrFunc) {
     run_configured_default_passes(func, &pipeline_opts);
 }
 
-fn run_configured_default_passes(func: &mut crate::ir::IrFunc, pipeline_opts: &PipelineOptions) {
+pub(crate) fn run_configured_default_passes(
+    func: &mut crate::ir::IrFunc,
+    pipeline_opts: &PipelineOptions,
+) {
+    run_configured_default_passes_with_observer(func, pipeline_opts, |_, _| {});
+}
+
+pub(crate) fn run_configured_default_passes_with_observer<F>(
+    func: &mut crate::ir::IrFunc,
+    pipeline_opts: &PipelineOptions,
+    mut observe_after_pass: F,
+) where
+    F: FnMut(&str, &crate::ir::IrFunc),
+{
     // r[impl compiler.opts.all-opts]
     if !pipeline_opts.resolve_all_opts(DEFAULT_PRE_LINEARIZATION_PASSES_ENABLED) {
         return;
     }
-    crate::ir_passes::run_default_passes_with_filter(func, |pass| {
-        pipeline_opts.resolve_pass(pass.name, true)
-    });
+
+    for pass in crate::ir_passes::default_pass_registry() {
+        if !pipeline_opts.resolve_pass(pass.name, true) {
+            continue;
+        }
+        pass.run(func);
+        observe_after_pass(pass.name, func);
+    }
 }
 
 // r[impl compiler.opts.regalloc]

--- a/kajit/src/lib.rs
+++ b/kajit/src/lib.rs
@@ -155,6 +155,43 @@ pub fn debug_linear_ir_text(
     scrub_volatile_intrinsic_addrs(&format!("{linear}"))
 }
 
+/// Build decoder IR and return textual RVSDG checkpoints before/after each enabled optimization pass.
+///
+/// The first entry is always `("initial", ir_before_passes)`.
+pub fn debug_ir_opt_timeline_text(
+    shape: &'static facet::Shape,
+    ir_decoder: &dyn format::Decoder,
+) -> Vec<(String, String)> {
+    let pipeline_opts = PipelineOptions::from_env();
+    debug_ir_opt_timeline_text_with_options(shape, ir_decoder, &pipeline_opts)
+}
+
+/// Same as [`debug_ir_opt_timeline_text`], but with explicit pipeline options.
+pub fn debug_ir_opt_timeline_text_with_options(
+    shape: &'static facet::Shape,
+    ir_decoder: &dyn format::Decoder,
+    pipeline_opts: &PipelineOptions,
+) -> Vec<(String, String)> {
+    let mut func = compiler::build_decoder_ir(shape, ir_decoder);
+    let mut checkpoints = vec![(
+        "initial".to_string(),
+        scrub_volatile_intrinsic_addrs(&format!("{func}")),
+    )];
+
+    compiler::run_configured_default_passes_with_observer(
+        &mut func,
+        pipeline_opts,
+        |pass, func| {
+            checkpoints.push((
+                pass.to_string(),
+                scrub_volatile_intrinsic_addrs(&format!("{func}")),
+            ));
+        },
+    );
+
+    checkpoints
+}
+
 fn scrub_volatile_intrinsic_addrs(text: &str) -> String {
     // Display dumps include intrinsic function pointer addresses which are process-local and
     // unstable across runs. Replace only those pointer fields to keep snapshots deterministic.

--- a/kajit/tests/corpus.rs
+++ b/kajit/tests/corpus.rs
@@ -480,63 +480,224 @@ where
         })
         .unwrap();
 }
-fn codegen_artifacts<T, F>(decoder: &F) -> (String, String, usize)
+const DUMP_STAGES_ENV: &str = "KAJIT_DUMP_STAGES";
+const DUMP_FILTER_ENV: &str = "KAJIT_DUMP_FILTER";
+const DUMP_DIR_ENV: &str = "KAJIT_DUMP_DIR";
+const ASSERT_SNAPSHOTS_ENV: &str = "KAJIT_ASSERT_CODEGEN_SNAPSHOTS";
+
+struct CodegenArtifacts {
+    ir_text: String,
+    linear_text: String,
+    ra_text: String,
+    edits: usize,
+    opt_timeline: Vec<(String, String)>,
+}
+
+fn codegen_artifacts<T, F>(decoder: &F) -> CodegenArtifacts
 where
     for<'input> T: Facet<'input>,
     F: kajit::format::Decoder,
 {
     let shape = T::SHAPE;
     let (ir_text, ra_text) = kajit::debug_ir_and_ra_mir_text(shape, decoder);
+    let linear_text = kajit::debug_linear_ir_text(shape, decoder);
     let edits = kajit::regalloc_edit_count(shape, decoder);
-    (ir_text, ra_text, edits)
+    let opt_timeline = kajit::debug_ir_opt_timeline_text(shape, decoder);
+    CodegenArtifacts {
+        ir_text,
+        linear_text,
+        ra_text,
+        edits,
+        opt_timeline,
+    }
+}
+
+fn env_truthy(name: &str) -> bool {
+    let Some(raw) = std::env::var_os(name) else {
+        return false;
+    };
+    let raw = raw.to_string_lossy();
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        "1" | "true" | "yes" | "on"
+    )
+}
+
+fn snapshot_assertions_enabled() -> bool {
+    env_truthy(ASSERT_SNAPSHOTS_ENV)
+}
+
+fn dump_stages() -> Option<Vec<String>> {
+    let raw = std::env::var_os(DUMP_STAGES_ENV)?;
+    let raw = raw.to_string_lossy();
+    let stages: Vec<String> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase())
+        .collect();
+    if stages.is_empty() {
+        None
+    } else {
+        Some(stages)
+    }
+}
+
+fn should_dump_stage(stage: &str) -> bool {
+    let Some(stages) = dump_stages() else {
+        return false;
+    };
+    stages.iter().any(|s| s == "all" || s == stage)
+}
+
+fn dump_filter_matches(target: &str) -> bool {
+    let Some(raw) = std::env::var_os(DUMP_FILTER_ENV) else {
+        return true;
+    };
+    let raw = raw.to_string_lossy();
+    let filters: Vec<&str> = raw
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if filters.is_empty() {
+        return true;
+    }
+    filters.iter().any(|needle| target.contains(needle))
+}
+
+fn dumps_enabled_for_case(format_label: &str, case: &str) -> bool {
+    if dump_stages().is_none() {
+        return false;
+    }
+    dump_filter_matches(&format!("{format_label}::{case}"))
+}
+
+fn default_dump_dir() -> std::path::PathBuf {
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    manifest_dir
+        .parent()
+        .map(|workspace_root| workspace_root.join("target/kajit-stage-dumps"))
+        .unwrap_or_else(|| manifest_dir.join("target/kajit-stage-dumps"))
+}
+
+fn dump_dir() -> std::path::PathBuf {
+    match std::env::var_os(DUMP_DIR_ENV) {
+        Some(raw) if !raw.is_empty() => std::path::PathBuf::from(raw),
+        _ => default_dump_dir(),
+    }
+}
+
+fn dump_stage(format_label: &str, case: &str, stage: &str, content: &str) {
+    let dir = dump_dir();
+    std::fs::create_dir_all(&dir).expect("failed to create dump directory");
+    let path = dir.join(format!(
+        "{format_label}__{case}__{}__{stage}.txt",
+        std::env::consts::ARCH
+    ));
+    std::fs::write(&path, content).unwrap_or_else(|error| {
+        panic!("failed writing dump to {}: {error}", path.display());
+    });
+}
+
+fn maybe_dump_codegen_artifacts(format_label: &str, case: &str, artifacts: &CodegenArtifacts) {
+    if !dumps_enabled_for_case(format_label, case) {
+        return;
+    }
+    if should_dump_stage("ir") {
+        dump_stage(format_label, case, "ir", &artifacts.ir_text);
+    }
+    if should_dump_stage("linear") {
+        dump_stage(format_label, case, "linear", &artifacts.linear_text);
+    }
+    if should_dump_stage("ra") {
+        dump_stage(format_label, case, "ra", &artifacts.ra_text);
+    }
+    if should_dump_stage("edits") {
+        dump_stage(format_label, case, "edits", &format!("{}", artifacts.edits));
+    }
+    if should_dump_stage("opts") {
+        for (index, (pass_name, ir_text)) in artifacts.opt_timeline.iter().enumerate() {
+            dump_stage(
+                format_label,
+                case,
+                &format!("opts_{index:02}_{pass_name}"),
+                ir_text,
+            );
+        }
+    }
 }
 fn assert_codegen_rvsdg_snapshot<T, F>(format_label: &str, case: &str, decoder: &F, _marker: &T)
 where
     for<'input> T: Facet<'input>,
     F: kajit::format::Decoder,
 {
-    let (ir_text, _ra_text, _edits) = codegen_artifacts::<T, F>(decoder);
-    insta::assert_snapshot!(
-        format!(
-            "generated_rvsdg_{}_{}_{}",
-            format_label,
-            case,
-            std::env::consts::ARCH
-        ),
-        ir_text
-    );
+    let should_assert = snapshot_assertions_enabled();
+    let should_dump = dumps_enabled_for_case(format_label, case);
+    if !should_assert && !should_dump {
+        return;
+    }
+    let artifacts = codegen_artifacts::<T, F>(decoder);
+    maybe_dump_codegen_artifacts(format_label, case, &artifacts);
+    if should_assert {
+        insta::assert_snapshot!(
+            format!(
+                "generated_rvsdg_{}_{}_{}",
+                format_label,
+                case,
+                std::env::consts::ARCH
+            ),
+            artifacts.ir_text
+        );
+    }
 }
 fn assert_codegen_ra_mir_snapshot<T, F>(format_label: &str, case: &str, decoder: &F, _marker: &T)
 where
     for<'input> T: Facet<'input>,
     F: kajit::format::Decoder,
 {
-    let (_ir_text, ra_text, _edits) = codegen_artifacts::<T, F>(decoder);
-    insta::assert_snapshot!(
-        format!(
-            "generated_ra_mir_{}_{}_{}",
-            format_label,
-            case,
-            std::env::consts::ARCH
-        ),
-        ra_text
-    );
+    let should_assert = snapshot_assertions_enabled();
+    let should_dump = dumps_enabled_for_case(format_label, case);
+    if !should_assert && !should_dump {
+        return;
+    }
+    let artifacts = codegen_artifacts::<T, F>(decoder);
+    maybe_dump_codegen_artifacts(format_label, case, &artifacts);
+    if should_assert {
+        insta::assert_snapshot!(
+            format!(
+                "generated_ra_mir_{}_{}_{}",
+                format_label,
+                case,
+                std::env::consts::ARCH
+            ),
+            artifacts.ra_text
+        );
+    }
 }
 fn assert_codegen_edits_snapshot<T, F>(format_label: &str, case: &str, decoder: &F, _marker: &T)
 where
     for<'input> T: Facet<'input>,
     F: kajit::format::Decoder,
 {
-    let (_ir_text, _ra_text, edits) = codegen_artifacts::<T, F>(decoder);
-    insta::assert_snapshot!(
-        format!(
-            "generated_postreg_edits_{}_{}_{}",
-            format_label,
-            case,
-            std::env::consts::ARCH
-        ),
-        format!("{edits}")
-    );
+    let should_assert = snapshot_assertions_enabled();
+    let should_dump = dumps_enabled_for_case(format_label, case);
+    if !should_assert && !should_dump {
+        return;
+    }
+    let artifacts = codegen_artifacts::<T, F>(decoder);
+    maybe_dump_codegen_artifacts(format_label, case, &artifacts);
+    if should_assert {
+        insta::assert_snapshot!(
+            format!(
+                "generated_postreg_edits_{}_{}_{}",
+                format_label,
+                case,
+                std::env::consts::ARCH
+            ),
+            format!("{}", artifacts.edits)
+        );
+    }
 }
 mod json {
     use super::*;
@@ -9079,20 +9240,23 @@ mod postreg {
     use super::*;
     #[test]
     fn vec_scalar_large_hotpath_asserts() {
-        let (ir_text, ra_text, edits) =
-            codegen_artifacts::<ScalarVec, _>(&kajit::postcard::KajitPostcard);
+        let artifacts = codegen_artifacts::<ScalarVec, _>(&kajit::postcard::KajitPostcard);
         assert!(
-            ir_text.contains("theta") || ir_text.contains("apply @"),
+            artifacts.ir_text.contains("theta") || artifacts.ir_text.contains("apply @"),
             "expected loop form (`theta`) or outlined loop body (`apply`) in IR"
         );
         assert!(
-            ra_text.contains("branch_if"),
+            artifacts.ra_text.contains("branch_if"),
             "expected loop backedge in RA-MIR"
         );
         assert!(
-            ra_text.contains("call_intrinsic"),
+            artifacts.ra_text.contains("call_intrinsic"),
             "expected intrinsic-heavy vec decode path in RA-MIR"
         );
-        assert!(edits <= 128, "expected edit budget <= 128, got {edits}");
+        assert!(
+            artifacts.edits <= 128,
+            "expected edit budget <= 128, got {}",
+            artifacts.edits
+        );
     }
 }

--- a/xtask/src/cases.rs
+++ b/xtask/src/cases.rs
@@ -2491,15 +2491,152 @@ pub(crate) fn render_test_file() -> String {
                 .unwrap();
         }
 
-        fn codegen_artifacts<T, F>(decoder: &F) -> (String, String, usize)
+        const DUMP_STAGES_ENV: &str = "KAJIT_DUMP_STAGES";
+        const DUMP_FILTER_ENV: &str = "KAJIT_DUMP_FILTER";
+        const DUMP_DIR_ENV: &str = "KAJIT_DUMP_DIR";
+        const ASSERT_SNAPSHOTS_ENV: &str = "KAJIT_ASSERT_CODEGEN_SNAPSHOTS";
+
+        struct CodegenArtifacts {
+            ir_text: String,
+            linear_text: String,
+            ra_text: String,
+            edits: usize,
+            opt_timeline: Vec<(String, String)>,
+        }
+
+        fn codegen_artifacts<T, F>(decoder: &F) -> CodegenArtifacts
         where
             for<'input> T: Facet<'input>,
             F: kajit::format::Decoder,
         {
             let shape = T::SHAPE;
             let (ir_text, ra_text) = kajit::debug_ir_and_ra_mir_text(shape, decoder);
+            let linear_text = kajit::debug_linear_ir_text(shape, decoder);
             let edits = kajit::regalloc_edit_count(shape, decoder);
-            (ir_text, ra_text, edits)
+            let opt_timeline = kajit::debug_ir_opt_timeline_text(shape, decoder);
+            CodegenArtifacts {
+                ir_text,
+                linear_text,
+                ra_text,
+                edits,
+                opt_timeline,
+            }
+        }
+
+        fn env_truthy(name: &str) -> bool {
+            let Some(raw) = std::env::var_os(name) else {
+                return false;
+            };
+            let raw = raw.to_string_lossy();
+            matches!(
+                raw.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes" | "on"
+            )
+        }
+
+        fn snapshot_assertions_enabled() -> bool {
+            env_truthy(ASSERT_SNAPSHOTS_ENV)
+        }
+
+        fn dump_stages() -> Option<Vec<String>> {
+            let raw = std::env::var_os(DUMP_STAGES_ENV)?;
+            let raw = raw.to_string_lossy();
+            let stages: Vec<String> = raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_ascii_lowercase())
+                .collect();
+            if stages.is_empty() {
+                None
+            } else {
+                Some(stages)
+            }
+        }
+
+        fn should_dump_stage(stage: &str) -> bool {
+            let Some(stages) = dump_stages() else {
+                return false;
+            };
+            stages.iter().any(|s| s == "all" || s == stage)
+        }
+
+        fn dump_filter_matches(target: &str) -> bool {
+            let Some(raw) = std::env::var_os(DUMP_FILTER_ENV) else {
+                return true;
+            };
+            let raw = raw.to_string_lossy();
+            let filters: Vec<&str> = raw
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .collect();
+            if filters.is_empty() {
+                return true;
+            }
+            filters.iter().any(|needle| target.contains(needle))
+        }
+
+        fn dumps_enabled_for_case(format_label: &str, case: &str) -> bool {
+            if dump_stages().is_none() {
+                return false;
+            }
+            dump_filter_matches(&format!("{format_label}::{case}"))
+        }
+
+        fn default_dump_dir() -> std::path::PathBuf {
+            let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+            manifest_dir
+                .parent()
+                .map(|workspace_root| workspace_root.join("target/kajit-stage-dumps"))
+                .unwrap_or_else(|| manifest_dir.join("target/kajit-stage-dumps"))
+        }
+
+        fn dump_dir() -> std::path::PathBuf {
+            match std::env::var_os(DUMP_DIR_ENV) {
+                Some(raw) if !raw.is_empty() => std::path::PathBuf::from(raw),
+                _ => default_dump_dir(),
+            }
+        }
+
+        fn dump_stage(format_label: &str, case: &str, stage: &str, content: &str) {
+            let dir = dump_dir();
+            std::fs::create_dir_all(&dir).expect("failed to create dump directory");
+            let path = dir.join(format!(
+                "{format_label}__{case}__{}__{stage}.txt",
+                std::env::consts::ARCH
+            ));
+            std::fs::write(&path, content).unwrap_or_else(|error| {
+                panic!("failed writing dump to {}: {error}", path.display());
+            });
+        }
+
+        fn maybe_dump_codegen_artifacts(format_label: &str, case: &str, artifacts: &CodegenArtifacts) {
+            if !dumps_enabled_for_case(format_label, case) {
+                return;
+            }
+            if should_dump_stage("ir") {
+                dump_stage(format_label, case, "ir", &artifacts.ir_text);
+            }
+            if should_dump_stage("linear") {
+                dump_stage(format_label, case, "linear", &artifacts.linear_text);
+            }
+            if should_dump_stage("ra") {
+                dump_stage(format_label, case, "ra", &artifacts.ra_text);
+            }
+            if should_dump_stage("edits") {
+                dump_stage(format_label, case, "edits", &format!("{}", artifacts.edits));
+            }
+            if should_dump_stage("opts") {
+                for (index, (pass_name, ir_text)) in artifacts.opt_timeline.iter().enumerate() {
+                    dump_stage(
+                        format_label,
+                        case,
+                        &format!("opts_{index:02}_{pass_name}"),
+                        ir_text,
+                    );
+                }
+            }
         }
 
         fn assert_codegen_rvsdg_snapshot<T, F>(
@@ -2512,16 +2649,24 @@ pub(crate) fn render_test_file() -> String {
             for<'input> T: Facet<'input>,
             F: kajit::format::Decoder,
         {
-            let (ir_text, _ra_text, _edits) = codegen_artifacts::<T, F>(decoder);
-            insta::assert_snapshot!(
-                format!(
-                    "generated_rvsdg_{}_{}_{}",
-                    format_label,
-                    case,
-                    std::env::consts::ARCH
-                ),
-                ir_text
-            );
+            let should_assert = snapshot_assertions_enabled();
+            let should_dump = dumps_enabled_for_case(format_label, case);
+            if !should_assert && !should_dump {
+                return;
+            }
+            let artifacts = codegen_artifacts::<T, F>(decoder);
+            maybe_dump_codegen_artifacts(format_label, case, &artifacts);
+            if should_assert {
+                insta::assert_snapshot!(
+                    format!(
+                        "generated_rvsdg_{}_{}_{}",
+                        format_label,
+                        case,
+                        std::env::consts::ARCH
+                    ),
+                    artifacts.ir_text
+                );
+            }
         }
 
         fn assert_codegen_ra_mir_snapshot<T, F>(
@@ -2534,16 +2679,24 @@ pub(crate) fn render_test_file() -> String {
             for<'input> T: Facet<'input>,
             F: kajit::format::Decoder,
         {
-            let (_ir_text, ra_text, _edits) = codegen_artifacts::<T, F>(decoder);
-            insta::assert_snapshot!(
-                format!(
-                    "generated_ra_mir_{}_{}_{}",
-                    format_label,
-                    case,
-                    std::env::consts::ARCH
-                ),
-                ra_text
-            );
+            let should_assert = snapshot_assertions_enabled();
+            let should_dump = dumps_enabled_for_case(format_label, case);
+            if !should_assert && !should_dump {
+                return;
+            }
+            let artifacts = codegen_artifacts::<T, F>(decoder);
+            maybe_dump_codegen_artifacts(format_label, case, &artifacts);
+            if should_assert {
+                insta::assert_snapshot!(
+                    format!(
+                        "generated_ra_mir_{}_{}_{}",
+                        format_label,
+                        case,
+                        std::env::consts::ARCH
+                    ),
+                    artifacts.ra_text
+                );
+            }
         }
 
         fn assert_codegen_edits_snapshot<T, F>(
@@ -2556,16 +2709,24 @@ pub(crate) fn render_test_file() -> String {
             for<'input> T: Facet<'input>,
             F: kajit::format::Decoder,
         {
-            let (_ir_text, _ra_text, edits) = codegen_artifacts::<T, F>(decoder);
-            insta::assert_snapshot!(
-                format!(
-                    "generated_postreg_edits_{}_{}_{}",
-                    format_label,
-                    case,
-                    std::env::consts::ARCH
-                ),
-                format!("{edits}")
-            );
+            let should_assert = snapshot_assertions_enabled();
+            let should_dump = dumps_enabled_for_case(format_label, case);
+            if !should_assert && !should_dump {
+                return;
+            }
+            let artifacts = codegen_artifacts::<T, F>(decoder);
+            maybe_dump_codegen_artifacts(format_label, case, &artifacts);
+            if should_assert {
+                insta::assert_snapshot!(
+                    format!(
+                        "generated_postreg_edits_{}_{}_{}",
+                        format_label,
+                        case,
+                        std::env::consts::ARCH
+                    ),
+                    format!("{}", artifacts.edits)
+                );
+            }
         }
 
         mod json {
@@ -2633,22 +2794,25 @@ pub(crate) fn render_test_file() -> String {
 
             #[test]
             fn vec_scalar_large_hotpath_asserts() {
-                let (ir_text, ra_text, edits) =
-                    codegen_artifacts::<ScalarVec, _>(&kajit::postcard::KajitPostcard);
+                let artifacts = codegen_artifacts::<ScalarVec, _>(&kajit::postcard::KajitPostcard);
 
                 assert!(
-                    ir_text.contains("theta") || ir_text.contains("apply @"),
+                    artifacts.ir_text.contains("theta") || artifacts.ir_text.contains("apply @"),
                     "expected loop form (`theta`) or outlined loop body (`apply`) in IR"
                 );
                 assert!(
-                    ra_text.contains("branch_if"),
+                    artifacts.ra_text.contains("branch_if"),
                     "expected loop backedge in RA-MIR"
                 );
                 assert!(
-                    ra_text.contains("call_intrinsic"),
+                    artifacts.ra_text.contains("call_intrinsic"),
                     "expected intrinsic-heavy vec decode path in RA-MIR"
                 );
-                assert!(edits <= 128, "expected edit budget <= 128, got {edits}");
+                assert!(
+                    artifacts.edits <= 128,
+                    "expected edit budget <= 128, got {}",
+                    artifacts.edits
+                );
             }
         }
     };


### PR DESCRIPTION
## Summary
- add a pass observer hook in compiler pass execution so callers can capture IR after each enabled default pass
- expose a new public debug API: `debug_ir_opt_timeline_text` (and `_with_options`) returning `initial` plus per-pass RVSDG checkpoints
- extend corpus codegen dump helpers with an `opts` stage that writes `opts_00_initial`, `opts_01_<pass>`, etc.
- switch default dump directory to workspace-level `target/kajit-stage-dumps` (instead of runtime cwd-relative)
- keep `xtask` corpus generator template in sync and document new behavior in `DEVELOP.md`

## Usage
```bash
KAJIT_DUMP_STAGES='opts' \
KAJIT_DUMP_FILTER='json::all_scalars' \
cargo nextest run -p kajit --test corpus -E 'test(=rvsdg_json::all_scalars)'
```

## Validation
- `cargo fmt`
- `cargo check -p kajit -p xtask`
- `KAJIT_DUMP_STAGES='opts' KAJIT_DUMP_FILTER='json::all_scalars' cargo nextest run -p kajit --test corpus -E 'test(=rvsdg_json::all_scalars)'`
- `cargo nextest run -p kajit --test corpus -E 'test(=ra_mir_json::all_scalars) or test(=postreg_edits_json::all_scalars)'`

## Notes
- `json::all_scalars` semantic failure still reproduces in this branch (expected / known ongoing issue), while the dump/test plumbing passes.
