### PR TITLE
kajit-emit: add trace/source-map utilities and hardening tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,23 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  kajit-emit:
+    runs-on: depot-ubuntu-24.04-16
+    name: test (kajit-emit)
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Test kajit-emit
+        run: cargo nextest run -p kajit-emit
+
   test:
     strategy:
       fail-fast: false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,6 +642,9 @@ dependencies = [
 [[package]]
 name = "kajit-emit"
 version = "0.1.0"
+dependencies = [
+ "proptest",
+]
 
 [[package]]
 name = "kajit-ir"

--- a/kajit-emit/Cargo.toml
+++ b/kajit-emit/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+
+[dev-dependencies]
+proptest = "1"

--- a/kajit-emit/src/aarch64.rs
+++ b/kajit-emit/src/aarch64.rs
@@ -78,6 +78,20 @@ pub struct FinalizedEmission {
     pub source_map: SourceMap,
 }
 
+impl FinalizedEmission {
+    pub fn trace_entries(&self) -> Result<Vec<crate::TraceEntry>, crate::TraceError> {
+        crate::build_trace(&self.code, &self.source_map)
+    }
+
+    pub fn trace_text(&self) -> Result<String, crate::TraceError> {
+        crate::format_trace(&self.code, &self.source_map)
+    }
+
+    pub fn source_map_le(&self) -> Result<Vec<u8>, crate::SourceMapError> {
+        crate::encode_source_map_le(&self.source_map)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EmitError {
     InvalidRegister {
@@ -801,6 +815,18 @@ mod tests {
         assert_eq!(word(&finalized.code[0..4]), 0x1400_0002);
         assert_eq!(word(&finalized.code[4..8]), 0xB4FF_FFF0);
         assert_eq!(word(&finalized.code[8..12]), 0x97FF_FFFE);
+
+        let trace = finalized.trace_text().unwrap();
+        assert_eq!(
+            trace,
+            "00000000 inst=10 bytes=02000014\n00000004 inst=11 bytes=f0ffffb4\n00000008 inst=12 bytes=feffff97"
+        );
+
+        let source_map_encoded = finalized.source_map_le().unwrap();
+        assert_eq!(
+            crate::decode_source_map_le(&source_map_encoded).unwrap(),
+            finalized.source_map
+        );
     }
 
     #[test]
@@ -830,5 +856,79 @@ mod tests {
                 ..
             }
         ));
+    }
+
+    #[test]
+    fn encode_boundaries_and_rejections() {
+        assert_eq!(encode_b(-(1 << 25)).unwrap(), 0x1600_0000);
+        assert_eq!(encode_b((1 << 25) - 1).unwrap(), 0x15FF_FFFF);
+        assert!(matches!(
+            encode_b(-(1 << 25) - 1),
+            Err(EmitError::InvalidImmediate {
+                instruction: "b",
+                ..
+            })
+        ));
+        assert!(matches!(
+            encode_b(1 << 25),
+            Err(EmitError::InvalidImmediate {
+                instruction: "b",
+                ..
+            })
+        ));
+
+        assert_eq!(encode_cbz(Width::X64, 0, -(1 << 18)).unwrap(), 0xB480_0000);
+        assert_eq!(
+            encode_cbz(Width::X64, 0, (1 << 18) - 1).unwrap(),
+            0xB47F_FFE0
+        );
+        assert!(matches!(
+            encode_cbz(Width::X64, 0, -(1 << 18) - 1),
+            Err(EmitError::InvalidImmediate {
+                instruction: "cbz",
+                ..
+            })
+        ));
+        assert!(matches!(
+            encode_cbz(Width::X64, 0, 1 << 18),
+            Err(EmitError::InvalidImmediate {
+                instruction: "cbz",
+                ..
+            })
+        ));
+
+        assert_eq!(
+            encode_ldr_imm(Width::X64, 1, 2, 4095 * 8).unwrap(),
+            0xF97F_FC41
+        );
+        assert!(matches!(
+            encode_ldr_imm(Width::X64, 1, 2, 4095 * 8 + 8),
+            Err(EmitError::InvalidOffset { .. })
+        ));
+        assert!(matches!(
+            encode_ldr_imm(Width::X64, 1, 2, 10),
+            Err(EmitError::InvalidOffset { .. })
+        ));
+
+        assert!(matches!(
+            encode_movz(Width::W32, 1, 0x1234, 32),
+            Err(EmitError::InvalidMovWideShift { .. })
+        ));
+        assert!(matches!(
+            encode_add_imm(Width::X64, 0, 0, 0x1000, false),
+            Err(EmitError::InvalidImmediate {
+                instruction: "add/sub imm12",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn emitter_rejects_double_label_bind() {
+        let mut emitter = Emitter::new();
+        let label = emitter.new_label();
+        emitter.bind_label(label).unwrap();
+        let err = emitter.bind_label(label).unwrap_err();
+        assert!(matches!(err, EmitError::LabelAlreadyBound { .. }));
     }
 }

--- a/kajit-emit/src/lib.rs
+++ b/kajit-emit/src/lib.rs
@@ -3,3 +3,180 @@ pub type SourceMap = Vec<(u32, RaMirInstIndex)>;
 
 pub mod aarch64;
 pub mod x64;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SourceMapError {
+    TruncatedBinary { len: usize },
+    UnsortedOffsets { previous: u32, next: u32 },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TraceError {
+    InvalidSourceMap(SourceMapError),
+    OffsetOutOfBounds { offset: u32, code_len: usize },
+}
+
+impl From<SourceMapError> for TraceError {
+    fn from(value: SourceMapError) -> Self {
+        Self::InvalidSourceMap(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraceEntry {
+    pub offset: u32,
+    pub ra_mir_inst_index: RaMirInstIndex,
+    pub bytes: Vec<u8>,
+}
+
+pub fn validate_source_map(source_map: &[(u32, RaMirInstIndex)]) -> Result<(), SourceMapError> {
+    for window in source_map.windows(2) {
+        let previous = window[0].0;
+        let next = window[1].0;
+        if next <= previous {
+            return Err(SourceMapError::UnsortedOffsets { previous, next });
+        }
+    }
+    Ok(())
+}
+
+pub fn encode_source_map_le(
+    source_map: &[(u32, RaMirInstIndex)],
+) -> Result<Vec<u8>, SourceMapError> {
+    validate_source_map(source_map)?;
+    let mut out = Vec::with_capacity(source_map.len() * 8);
+    for (offset, inst) in source_map {
+        out.extend_from_slice(&offset.to_le_bytes());
+        out.extend_from_slice(&inst.to_le_bytes());
+    }
+    Ok(out)
+}
+
+pub fn decode_source_map_le(bytes: &[u8]) -> Result<SourceMap, SourceMapError> {
+    if !bytes.len().is_multiple_of(8) {
+        return Err(SourceMapError::TruncatedBinary { len: bytes.len() });
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 8);
+    for chunk in bytes.chunks_exact(8) {
+        let offset = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+        let inst = u32::from_le_bytes([chunk[4], chunk[5], chunk[6], chunk[7]]);
+        out.push((offset, inst));
+    }
+    validate_source_map(&out)?;
+    Ok(out)
+}
+
+pub fn build_trace(
+    code: &[u8],
+    source_map: &[(u32, RaMirInstIndex)],
+) -> Result<Vec<TraceEntry>, TraceError> {
+    validate_source_map(source_map)?;
+    let mut out = Vec::with_capacity(source_map.len());
+    for (index, (offset, inst)) in source_map.iter().copied().enumerate() {
+        if offset as usize >= code.len() {
+            return Err(TraceError::OffsetOutOfBounds {
+                offset,
+                code_len: code.len(),
+            });
+        }
+        let next_offset = source_map
+            .get(index + 1)
+            .map(|(next, _)| *next as usize)
+            .unwrap_or(code.len());
+        if next_offset > code.len() {
+            return Err(TraceError::OffsetOutOfBounds {
+                offset: next_offset as u32,
+                code_len: code.len(),
+            });
+        }
+        let start = offset as usize;
+        let bytes = code[start..next_offset].to_vec();
+        out.push(TraceEntry {
+            offset,
+            ra_mir_inst_index: inst,
+            bytes,
+        });
+    }
+    Ok(out)
+}
+
+pub fn format_trace_entries(entries: &[TraceEntry]) -> String {
+    entries
+        .iter()
+        .map(|entry| {
+            let hex = entry
+                .bytes
+                .iter()
+                .map(|byte| format!("{byte:02x}"))
+                .collect::<String>();
+            format!(
+                "{:08x} inst={} bytes={}",
+                entry.offset, entry.ra_mir_inst_index, hex
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+pub fn format_trace(
+    code: &[u8],
+    source_map: &[(u32, RaMirInstIndex)],
+) -> Result<String, TraceError> {
+    let entries = build_trace(code, source_map)?;
+    Ok(format_trace_entries(&entries))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn source_map_roundtrip_binary_codec() {
+        let source_map = vec![(0, 12), (4, 13), (7, 14)];
+        let encoded = encode_source_map_le(&source_map).unwrap();
+        let decoded = decode_source_map_le(&encoded).unwrap();
+        assert_eq!(decoded, source_map);
+    }
+
+    #[test]
+    fn source_map_codec_rejects_invalid_input() {
+        let err = decode_source_map_le(&[0u8; 3]).unwrap_err();
+        assert!(matches!(err, SourceMapError::TruncatedBinary { len: 3 }));
+
+        let err = encode_source_map_le(&[(4, 1), (4, 2)]).unwrap_err();
+        assert!(matches!(
+            err,
+            SourceMapError::UnsortedOffsets {
+                previous: 4,
+                next: 4
+            }
+        ));
+    }
+
+    #[test]
+    fn trace_builds_and_formats() {
+        let code = vec![0x90, 0x90, 0x0f, 0x84, 0x34, 0x12, 0x00, 0x00];
+        let source_map = vec![(0, 10), (2, 11)];
+        let trace = build_trace(&code, &source_map).unwrap();
+        assert_eq!(trace[0].bytes, vec![0x90, 0x90]);
+        assert_eq!(trace[1].bytes, vec![0x0f, 0x84, 0x34, 0x12, 0x00, 0x00]);
+
+        let text = format_trace_entries(&trace);
+        assert_eq!(
+            text,
+            "00000000 inst=10 bytes=9090\n00000002 inst=11 bytes=0f8434120000"
+        );
+    }
+
+    #[test]
+    fn trace_rejects_out_of_bounds_offsets() {
+        let err = build_trace(&[0x90], &[(1, 0)]).unwrap_err();
+        assert!(matches!(
+            err,
+            TraceError::OffsetOutOfBounds {
+                offset: 1,
+                code_len: 1
+            }
+        ));
+    }
+}

--- a/kajit-emit/src/x64.rs
+++ b/kajit-emit/src/x64.rs
@@ -15,6 +15,20 @@ pub struct FinalizedEmission {
     pub source_map: SourceMap,
 }
 
+impl FinalizedEmission {
+    pub fn trace_entries(&self) -> Result<Vec<crate::TraceEntry>, crate::TraceError> {
+        crate::build_trace(&self.code, &self.source_map)
+    }
+
+    pub fn trace_text(&self) -> Result<String, crate::TraceError> {
+        crate::format_trace(&self.code, &self.source_map)
+    }
+
+    pub fn source_map_le(&self) -> Result<Vec<u8>, crate::SourceMapError> {
+        crate::encode_source_map_le(&self.source_map)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Operand {
     Reg(u8),
@@ -790,6 +804,18 @@ mod tests {
                 0x0f, 0x85, 0xef, 0xff, 0xff, 0xff, // jnz -17
             ]
         );
+
+        let trace = finalized.trace_text().unwrap();
+        assert_eq!(
+            trace,
+            "00000000 inst=10 bytes=0f8405000000\n00000006 inst=11 bytes=e8f5ffffff\n0000000b inst=12 bytes=0f85efffffff"
+        );
+
+        let source_map_encoded = finalized.source_map_le().unwrap();
+        assert_eq!(
+            crate::decode_source_map_le(&source_map_encoded).unwrap(),
+            finalized.source_map
+        );
     }
 
     #[test]
@@ -816,5 +842,53 @@ mod tests {
         let mut buf = Vec::new();
         let err = encode_mov_r64_r64(0, 16, &mut buf).unwrap_err();
         assert!(matches!(err, EmitError::InvalidRegister { reg: 16 }));
+    }
+
+    #[test]
+    fn encode_disp_size_boundaries() {
+        let mut buf = Vec::new();
+        encode_mov_m_r64(Mem { base: 5, disp: 0 }, 10, &mut buf).unwrap();
+        assert_eq!(buf, [0x4c, 0x89, 0x55, 0x00]);
+
+        buf.clear();
+        encode_mov_m_r64(Mem { base: 5, disp: 127 }, 10, &mut buf).unwrap();
+        assert_eq!(buf, [0x4c, 0x89, 0x55, 0x7f]);
+
+        buf.clear();
+        encode_mov_m_r64(Mem { base: 5, disp: 128 }, 10, &mut buf).unwrap();
+        assert_eq!(buf, [0x4c, 0x89, 0x95, 0x80, 0x00, 0x00, 0x00]);
+    }
+
+    #[test]
+    fn encode_rex_for_low_byte_registers() {
+        let mut buf = Vec::new();
+        encode_setne_r8(4, &mut buf).unwrap(); // spl
+        assert_eq!(buf, [0x40, 0x0f, 0x95, 0xc4]);
+
+        buf.clear();
+        encode_movzx_r64_rm8(0, Operand::Reg(4), &mut buf).unwrap(); // movzx rax, spl
+        assert_eq!(buf, [0x48, 0x0f, 0xb6, 0xc4]);
+    }
+
+    #[test]
+    fn emitter_resolves_forward_and_backward_jumps() {
+        let mut emitter = Emitter::new();
+        let start = emitter.new_label();
+        let target = emitter.new_label();
+        emitter.bind_label(start).unwrap();
+        emitter.emit_jmp_label(1, target).unwrap();
+        emitter.emit_bytes(2, &[0x90, 0x90]); // 2 nops
+        emitter.bind_label(target).unwrap();
+        emitter.emit_jz_label(3, start).unwrap();
+
+        let finalized = emitter.finalize().unwrap();
+        assert_eq!(
+            finalized.code,
+            vec![
+                0xe9, 0x02, 0x00, 0x00, 0x00, // jmp +2
+                0x90, 0x90, // nops
+                0x0f, 0x84, 0xf3, 0xff, 0xff, 0xff, // jz -13
+            ]
+        );
     }
 }

--- a/kajit-emit/tests/property.rs
+++ b/kajit-emit/tests/property.rs
@@ -1,0 +1,101 @@
+use kajit_emit::aarch64::{self, Width as A64Width};
+use kajit_emit::x64::{self, Emitter as X64Emitter};
+use proptest::prelude::*;
+
+fn sign_extend_u32(value: u32, bits: u8) -> i32 {
+    let shift = 32 - bits;
+    ((value << shift) as i32) >> shift
+}
+
+proptest! {
+    #[test]
+    fn aarch64_add_reg_fields_roundtrip(
+        is_64 in any::<bool>(),
+        rd in 0u8..32,
+        rn in 0u8..32,
+        rm in 0u8..32,
+    ) {
+        let width = if is_64 { A64Width::X64 } else { A64Width::W32 };
+        let word = aarch64::encode_add_reg(width, rd, rn, rm).unwrap();
+        prop_assert_eq!(word & 0x1f, rd as u32);
+        prop_assert_eq!((word >> 5) & 0x1f, rn as u32);
+        prop_assert_eq!((word >> 16) & 0x1f, rm as u32);
+        prop_assert_eq!((word >> 31) & 1, if is_64 { 1 } else { 0 });
+    }
+
+    #[test]
+    fn aarch64_branch_imm_roundtrip(imm in -33_554_432i32..33_554_432i32) {
+        let word = aarch64::encode_b(imm).unwrap();
+        let decoded = sign_extend_u32(word & 0x03ff_ffff, 26);
+        prop_assert_eq!(decoded, imm);
+    }
+
+    #[test]
+    fn aarch64_cbz_imm_roundtrip(
+        is_64 in any::<bool>(),
+        rt in 0u8..32,
+        imm in -262_144i32..262_144i32,
+    ) {
+        let width = if is_64 { A64Width::X64 } else { A64Width::W32 };
+        let word = aarch64::encode_cbz(width, rt, imm).unwrap();
+        let decoded = sign_extend_u32((word >> 5) & 0x7ffff, 19);
+        prop_assert_eq!(decoded, imm);
+    }
+
+    #[test]
+    fn x64_call_rel32_roundtrip(disp in any::<i32>()) {
+        let mut buf = Vec::new();
+        x64::encode_call_rel32(&mut buf, disp).unwrap();
+        let parsed = i32::from_le_bytes(buf[1..5].try_into().unwrap());
+        prop_assert_eq!(parsed, disp);
+    }
+
+    #[test]
+    fn x64_reg_to_reg_mov_is_compact(
+        dst in 0u8..16,
+        src in 0u8..16,
+    ) {
+        let mut buf = Vec::new();
+        x64::encode_mov_r64_r64(dst, src, &mut buf).unwrap();
+        prop_assert_eq!(buf.len(), 3);
+    }
+
+    #[test]
+    fn x64_emitter_fixup_forward_delta_matches_padding(padding in 0usize..1024) {
+        let mut emitter = X64Emitter::new();
+        let target = emitter.new_label();
+        emitter.emit_call_label(0, target).unwrap();
+        for _ in 0..padding {
+            emitter.emit_bytes(1, &[0x90]);
+        }
+        emitter.bind_label(target).unwrap();
+
+        let finalized = emitter.finalize().unwrap();
+        let disp = i32::from_le_bytes(finalized.code[1..5].try_into().unwrap());
+        prop_assert_eq!(disp, padding as i32);
+    }
+
+    #[test]
+    fn x64_emitter_fixup_backward_delta_matches_padding(padding in 0usize..1024) {
+        let mut emitter = X64Emitter::new();
+        let target = emitter.new_label();
+        emitter.bind_label(target).unwrap();
+        for _ in 0..padding {
+            emitter.emit_bytes(1, &[0x90]);
+        }
+        emitter.emit_call_label(0, target).unwrap();
+
+        let finalized = emitter.finalize().unwrap();
+        let disp_offset = finalized.code.len() - 4;
+        let disp = i32::from_le_bytes(finalized.code[disp_offset..].try_into().unwrap());
+        prop_assert_eq!(disp, -((padding as i32) + 5));
+    }
+
+    #[test]
+    fn x64_invalid_registers_are_rejected(reg in 16u8..=u8::MAX) {
+        let mut buf = Vec::new();
+        let err = x64::encode_push_r64(reg, &mut buf).unwrap_err();
+        let is_invalid = matches!(err, x64::EmitError::InvalidRegister { reg: r } if r == reg);
+        prop_assert!(is_invalid);
+    }
+}


### PR DESCRIPTION
## Summary
Follow-up hardening for the standalone `kajit-emit` crate, without touching backend integration paths.

## Changes
- Add source-map serialization helpers and validation (`encode_source_map_le`, `decode_source_map_le`, validation)
- Add emission trace utilities (`build_trace`, `format_trace`) for deterministic textual snapshots
- Expose convenience APIs on finalized emissions for both `aarch64` and `x64`
  - `trace_entries()`
  - `trace_text()`
  - `source_map_le()`
- Expand boundary/error test coverage in `aarch64` and `x64` modules
- Add property tests with `proptest` for encoding/fixup invariants
- Add a dedicated CI job to run `cargo nextest run -p kajit-emit`

## Validation
- `cargo nextest run -p kajit-emit`
  - Passed: 35
  - Failed: 0

Part of #157.
