### PR TITLE
jit: prep DWARF sections for JIT registration

### DIFF
--- a/kajit/src/jit_debug.rs
+++ b/kajit/src/jit_debug.rs
@@ -126,7 +126,20 @@ pub fn register_jit_code(
     buf_len: usize,
     symbols: &[JitSymbolEntry],
 ) -> JitRegistration {
-    let elf = build_elf(buf_base as u64, buf_len, symbols);
+    register_jit_code_with_dwarf(buf_base, buf_len, symbols, None)
+}
+
+/// Register JIT-compiled code with optional DWARF sections.
+///
+/// Existing call sites can keep using `register_jit_code`; this is the
+/// preparatory API for attaching `.debug_line` payloads later.
+pub fn register_jit_code_with_dwarf(
+    buf_base: *const u8,
+    buf_len: usize,
+    symbols: &[JitSymbolEntry],
+    dwarf: Option<&crate::jit_dwarf::JitDwarfSections>,
+) -> JitRegistration {
+    let elf = build_elf(buf_base as u64, buf_len, symbols, dwarf);
 
     let entry = Box::into_raw(Box::new(JitCodeEntry {
         next: std::ptr::null_mut(),
@@ -195,7 +208,6 @@ const STT_FUNC: u8 = 2;
 const EHDR_SIZE: usize = 64;
 const SHDR_SIZE: usize = 64;
 const SYM_SIZE: usize = 24;
-const NUM_SECTIONS: usize = 5; // null, .text, .symtab, .strtab, .shstrtab
 
 #[cfg(target_arch = "x86_64")]
 const EM_MACHINE: u16 = 0x3E; // EM_X86_64
@@ -206,7 +218,24 @@ const EM_MACHINE: u16 = 0xB7; // EM_AARCH64
 #[cfg(not(any(target_arch = "x86_64", target_arch = "aarch64")))]
 const EM_MACHINE: u16 = 0;
 
-fn build_elf(text_addr: u64, text_len: usize, symbols: &[JitSymbolEntry]) -> Vec<u8> {
+struct ExtraSection<'a> {
+    name: &'a str,
+    sh_type: u32,
+    sh_flags: u64,
+    sh_addr: u64,
+    sh_link: u32,
+    sh_info: u32,
+    sh_addralign: u64,
+    sh_entsize: u64,
+    data: &'a [u8],
+}
+
+fn build_elf(
+    text_addr: u64,
+    text_len: usize,
+    symbols: &[JitSymbolEntry],
+    dwarf: Option<&crate::jit_dwarf::JitDwarfSections>,
+) -> Vec<u8> {
     // Build .strtab (symbol name strings)
     let mut strtab = vec![0u8]; // index 0 = empty string
     let mut name_offsets = Vec::with_capacity(symbols.len());
@@ -215,18 +244,6 @@ fn build_elf(text_addr: u64, text_len: usize, symbols: &[JitSymbolEntry]) -> Vec
         strtab.extend_from_slice(sym.name.as_bytes());
         strtab.push(0);
     }
-
-    // Build .shstrtab (section name strings)
-    let mut shstrtab = vec![0u8];
-    let sh_name_null = 0u32;
-    let sh_name_text = shstrtab.len() as u32;
-    shstrtab.extend_from_slice(b".text\0");
-    let sh_name_symtab = shstrtab.len() as u32;
-    shstrtab.extend_from_slice(b".symtab\0");
-    let sh_name_strtab = shstrtab.len() as u32;
-    shstrtab.extend_from_slice(b".strtab\0");
-    let sh_name_shstrtab = shstrtab.len() as u32;
-    shstrtab.extend_from_slice(b".shstrtab\0");
 
     // Build .symtab
     // Entry 0: null symbol
@@ -251,12 +268,82 @@ fn build_elf(text_addr: u64, text_len: usize, symbols: &[JitSymbolEntry]) -> Vec
         symtab.extend_from_slice(&(sym.size as u64).to_le_bytes());
     }
 
-    // Layout: ELF header | section headers | .symtab | .strtab | .shstrtab
+    let mut extras = Vec::<ExtraSection<'_>>::new();
+    if let Some(dwarf) = dwarf {
+        if !dwarf.debug_line.is_empty() {
+            extras.push(ExtraSection {
+                name: ".debug_line",
+                sh_type: SHT_PROGBITS,
+                sh_flags: 0,
+                sh_addr: 0,
+                sh_link: 0,
+                sh_info: 0,
+                sh_addralign: 1,
+                sh_entsize: 0,
+                data: &dwarf.debug_line,
+            });
+        }
+        if !dwarf.debug_str.is_empty() {
+            extras.push(ExtraSection {
+                name: ".debug_str",
+                sh_type: SHT_STRTAB,
+                sh_flags: 0,
+                sh_addr: 0,
+                sh_link: 0,
+                sh_info: 0,
+                sh_addralign: 1,
+                sh_entsize: 0,
+                data: &dwarf.debug_str,
+            });
+        }
+        if !dwarf.debug_line_str.is_empty() {
+            extras.push(ExtraSection {
+                name: ".debug_line_str",
+                sh_type: SHT_STRTAB,
+                sh_flags: 0,
+                sh_addr: 0,
+                sh_link: 0,
+                sh_info: 0,
+                sh_addralign: 1,
+                sh_entsize: 0,
+                data: &dwarf.debug_line_str,
+            });
+        }
+    }
+
+    // Build .shstrtab (section name strings)
+    let mut shstrtab = vec![0u8];
+    let sh_name_null = 0u32;
+    let sh_name_text = shstrtab.len() as u32;
+    shstrtab.extend_from_slice(b".text\0");
+    let sh_name_symtab = shstrtab.len() as u32;
+    shstrtab.extend_from_slice(b".symtab\0");
+    let sh_name_strtab = shstrtab.len() as u32;
+    shstrtab.extend_from_slice(b".strtab\0");
+    let mut extra_name_offsets = Vec::with_capacity(extras.len());
+    for extra in &extras {
+        let off = shstrtab.len() as u32;
+        shstrtab.extend_from_slice(extra.name.as_bytes());
+        shstrtab.push(0);
+        extra_name_offsets.push(off);
+    }
+    let sh_name_shstrtab = shstrtab.len() as u32;
+    shstrtab.extend_from_slice(b".shstrtab\0");
+
+    // Layout: ELF header | section headers | section data blobs
+    let num_sections = 5 + extras.len(); // null, .text, .symtab, .strtab, extras..., .shstrtab
+    let shstrtab_index = 4 + extras.len();
     let shdr_offset = EHDR_SIZE;
-    let data_offset = EHDR_SIZE + NUM_SECTIONS * SHDR_SIZE;
+    let data_offset = EHDR_SIZE + num_sections * SHDR_SIZE;
     let symtab_off = data_offset;
     let strtab_off = symtab_off + symtab.len();
-    let shstrtab_off = strtab_off + strtab.len();
+    let mut extra_offsets = Vec::with_capacity(extras.len());
+    let mut cursor = strtab_off + strtab.len();
+    for extra in &extras {
+        extra_offsets.push(cursor);
+        cursor += extra.data.len();
+    }
+    let shstrtab_off = cursor;
     let total_size = shstrtab_off + shstrtab.len();
 
     let mut elf = Vec::with_capacity(total_size);
@@ -278,8 +365,8 @@ fn build_elf(text_addr: u64, text_len: usize, symbols: &[JitSymbolEntry]) -> Vec
     elf.extend_from_slice(&0u16.to_le_bytes()); // e_phentsize
     elf.extend_from_slice(&0u16.to_le_bytes()); // e_phnum
     elf.extend_from_slice(&(SHDR_SIZE as u16).to_le_bytes()); // e_shentsize
-    elf.extend_from_slice(&(NUM_SECTIONS as u16).to_le_bytes()); // e_shnum
-    elf.extend_from_slice(&4u16.to_le_bytes()); // e_shstrndx (index of .shstrtab)
+    elf.extend_from_slice(&(num_sections as u16).to_le_bytes()); // e_shnum
+    elf.extend_from_slice(&(shstrtab_index as u16).to_le_bytes()); // e_shstrndx (index of .shstrtab)
     debug_assert_eq!(elf.len(), EHDR_SIZE);
 
     // ----- Section headers -----
@@ -332,6 +419,22 @@ fn build_elf(text_addr: u64, text_len: usize, symbols: &[JitSymbolEntry]) -> Vec
         0,
     );
 
+    for (index, extra) in extras.iter().enumerate() {
+        write_shdr(
+            &mut elf,
+            extra_name_offsets[index],
+            extra.sh_type,
+            extra.sh_flags,
+            extra.sh_addr,
+            extra_offsets[index] as u64,
+            extra.data.len() as u64,
+            extra.sh_link,
+            extra.sh_info,
+            extra.sh_addralign,
+            extra.sh_entsize,
+        );
+    }
+
     // [4] .shstrtab
     write_shdr(
         &mut elf,
@@ -352,6 +455,9 @@ fn build_elf(text_addr: u64, text_len: usize, symbols: &[JitSymbolEntry]) -> Vec
     // ----- Section data -----
     elf.extend_from_slice(&symtab);
     elf.extend_from_slice(&strtab);
+    for extra in &extras {
+        elf.extend_from_slice(extra.data);
+    }
     elf.extend_from_slice(&shstrtab);
 
     debug_assert_eq!(elf.len(), total_size);
@@ -382,4 +488,89 @@ fn write_shdr(
     buf.extend_from_slice(&sh_info.to_le_bytes());
     buf.extend_from_slice(&sh_addralign.to_le_bytes());
     buf.extend_from_slice(&sh_entsize.to_le_bytes());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn read_u16(bytes: &[u8], offset: usize) -> u16 {
+        u16::from_le_bytes(bytes[offset..offset + 2].try_into().unwrap())
+    }
+
+    fn read_u32(bytes: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes(bytes[offset..offset + 4].try_into().unwrap())
+    }
+
+    fn read_u64(bytes: &[u8], offset: usize) -> u64 {
+        u64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())
+    }
+
+    fn read_section_names(elf: &[u8]) -> Vec<String> {
+        let shoff = read_u64(elf, 40) as usize;
+        let shentsize = read_u16(elf, 58) as usize;
+        let shnum = read_u16(elf, 60) as usize;
+        let shstrndx = read_u16(elf, 62) as usize;
+
+        let shstr_off = read_u64(elf, shoff + shstrndx * shentsize + 24) as usize;
+        let shstr_size = read_u64(elf, shoff + shstrndx * shentsize + 32) as usize;
+        let shstr = &elf[shstr_off..shstr_off + shstr_size];
+
+        (0..shnum)
+            .map(|index| {
+                let sh_name = read_u32(elf, shoff + index * shentsize) as usize;
+                if sh_name == 0 {
+                    return String::new();
+                }
+                let tail = &shstr[sh_name..];
+                let end = tail.iter().position(|b| *b == 0).unwrap();
+                String::from_utf8(tail[..end].to_vec()).unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn elf_without_dwarf_sections_keeps_base_layout() {
+        let elf = build_elf(
+            0x1000,
+            32,
+            &[JitSymbolEntry {
+                name: "jit::root".to_string(),
+                offset: 0,
+                size: 32,
+            }],
+            None,
+        );
+        let names = read_section_names(&elf);
+        assert!(names.contains(&".text".to_string()));
+        assert!(names.contains(&".symtab".to_string()));
+        assert!(names.contains(&".strtab".to_string()));
+        assert!(!names.contains(&".debug_line".to_string()));
+    }
+
+    #[test]
+    fn elf_with_dwarf_sections_contains_debug_line() {
+        let dwarf = crate::jit_dwarf::build_jit_dwarf_sections(
+            0x2000,
+            16,
+            &[(0, 0), (4, 1)],
+            "decoder.ra",
+            Some("jit"),
+        )
+        .unwrap();
+
+        let elf = build_elf(
+            0x2000,
+            16,
+            &[JitSymbolEntry {
+                name: "jit::root".to_string(),
+                offset: 0,
+                size: 16,
+            }],
+            Some(&dwarf),
+        );
+
+        let names = read_section_names(&elf);
+        assert!(names.contains(&".debug_line".to_string()));
+    }
 }

--- a/kajit/src/jit_dwarf.rs
+++ b/kajit/src/jit_dwarf.rs
@@ -1,0 +1,363 @@
+//! DWARF preparation utilities for JIT code.
+//!
+//! This module builds a minimal DWARF v4 `.debug_line` section from a source
+//! map of `(code_offset, ra_mir_inst_index)` pairs.
+
+/// Owned DWARF sections ready to be attached to the JIT ELF.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct JitDwarfSections {
+    pub debug_line: Vec<u8>,
+    pub debug_str: Vec<u8>,
+    pub debug_line_str: Vec<u8>,
+}
+
+impl JitDwarfSections {
+    pub fn is_empty(&self) -> bool {
+        self.debug_line.is_empty() && self.debug_str.is_empty() && self.debug_line_str.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DwarfPrepError {
+    InteriorNul {
+        field: &'static str,
+    },
+    SourceMapNotStrictlyIncreasing {
+        previous_offset: u32,
+        next_offset: u32,
+    },
+    SourceOffsetOutOfBounds {
+        offset: u32,
+        code_size: u64,
+    },
+    CodeSizeOutOfBounds {
+        code_size: u64,
+    },
+}
+
+const DW_LNS_COPY: u8 = 1;
+const DW_LNS_ADVANCE_PC: u8 = 2;
+const DW_LNS_ADVANCE_LINE: u8 = 3;
+
+const DW_LNE_END_SEQUENCE: u8 = 1;
+const DW_LNE_SET_ADDRESS: u8 = 2;
+
+const LINE_VERSION: u16 = 4;
+const MIN_INSN_LEN: u8 = 1;
+const MAX_OPS_PER_INSN: u8 = 1;
+const DEFAULT_IS_STMT: u8 = 1;
+const LINE_BASE: i8 = -5;
+const LINE_RANGE: u8 = 14;
+const OPCODE_BASE: u8 = 13;
+const STANDARD_OPCODE_LENGTHS: [u8; 12] = [0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1];
+
+/// Build DWARF sections for one JIT function.
+///
+/// `source_map` entries are interpreted as:
+/// - address: `code_address + code_offset`
+/// - line: `ra_mir_inst_index + 1`
+pub fn build_jit_dwarf_sections(
+    code_address: u64,
+    code_size: u64,
+    source_map: &[(u32, u32)],
+    file_name: &str,
+    directory: Option<&str>,
+) -> Result<JitDwarfSections, DwarfPrepError> {
+    Ok(JitDwarfSections {
+        debug_line: build_debug_line_section(
+            code_address,
+            code_size,
+            source_map,
+            file_name,
+            directory,
+        )?,
+        debug_str: Vec::new(),
+        debug_line_str: Vec::new(),
+    })
+}
+
+pub fn build_debug_line_section(
+    code_address: u64,
+    code_size: u64,
+    source_map: &[(u32, u32)],
+    file_name: &str,
+    directory: Option<&str>,
+) -> Result<Vec<u8>, DwarfPrepError> {
+    if code_size > u32::MAX as u64 {
+        return Err(DwarfPrepError::CodeSizeOutOfBounds { code_size });
+    }
+    if file_name.as_bytes().contains(&0) {
+        return Err(DwarfPrepError::InteriorNul { field: "file_name" });
+    }
+    if let Some(dir) = directory {
+        if dir.as_bytes().contains(&0) {
+            return Err(DwarfPrepError::InteriorNul { field: "directory" });
+        }
+    }
+
+    for window in source_map.windows(2) {
+        let previous = window[0].0;
+        let next = window[1].0;
+        if next <= previous {
+            return Err(DwarfPrepError::SourceMapNotStrictlyIncreasing {
+                previous_offset: previous,
+                next_offset: next,
+            });
+        }
+    }
+
+    for (offset, _) in source_map {
+        if (*offset as u64) > code_size {
+            return Err(DwarfPrepError::SourceOffsetOutOfBounds {
+                offset: *offset,
+                code_size,
+            });
+        }
+    }
+
+    let mut header_body = Vec::new();
+    header_body.push(MIN_INSN_LEN);
+    header_body.push(MAX_OPS_PER_INSN);
+    header_body.push(DEFAULT_IS_STMT);
+    header_body.push(LINE_BASE as u8);
+    header_body.push(LINE_RANGE);
+    header_body.push(OPCODE_BASE);
+    header_body.extend_from_slice(&STANDARD_OPCODE_LENGTHS);
+
+    let has_dir = directory.is_some_and(|dir| !dir.is_empty());
+    if let Some(dir) = directory.filter(|dir| !dir.is_empty()) {
+        header_body.extend_from_slice(dir.as_bytes());
+        header_body.push(0);
+    }
+    header_body.push(0); // end include_directories
+
+    header_body.extend_from_slice(file_name.as_bytes());
+    header_body.push(0);
+    push_uleb128(&mut header_body, if has_dir { 1 } else { 0 });
+    push_uleb128(&mut header_body, 0); // mtime
+    push_uleb128(&mut header_body, 0); // size
+    header_body.push(0); // end file_names
+
+    let mut program = Vec::new();
+    // Extended opcode: set absolute text address for sequence.
+    program.push(0);
+    push_uleb128(&mut program, 1 + 8);
+    program.push(DW_LNE_SET_ADDRESS);
+    program.extend_from_slice(&code_address.to_le_bytes());
+
+    let mut current_offset = 0u64;
+    let mut current_line = 1i64;
+
+    for (offset, ra_mir_inst_index) in source_map {
+        let offset = *offset as u64;
+        let line = (*ra_mir_inst_index as i64) + 1;
+
+        if offset > current_offset {
+            program.push(DW_LNS_ADVANCE_PC);
+            push_uleb128(&mut program, offset - current_offset);
+            current_offset = offset;
+        }
+
+        let delta_line = line - current_line;
+        if delta_line != 0 {
+            program.push(DW_LNS_ADVANCE_LINE);
+            push_sleb128(&mut program, delta_line);
+            current_line = line;
+        }
+
+        program.push(DW_LNS_COPY);
+    }
+
+    if code_size > current_offset {
+        program.push(DW_LNS_ADVANCE_PC);
+        push_uleb128(&mut program, code_size - current_offset);
+    }
+
+    program.push(0);
+    push_uleb128(&mut program, 1);
+    program.push(DW_LNE_END_SEQUENCE);
+
+    let header_length = header_body.len() as u32;
+    let unit_length = 2u32 + 4u32 + header_length + (program.len() as u32);
+
+    let mut section = Vec::with_capacity(4 + unit_length as usize);
+    section.extend_from_slice(&unit_length.to_le_bytes());
+    section.extend_from_slice(&LINE_VERSION.to_le_bytes());
+    section.extend_from_slice(&header_length.to_le_bytes());
+    section.extend_from_slice(&header_body);
+    section.extend_from_slice(&program);
+    section.shrink_to_fit();
+    Ok(section)
+}
+
+fn push_uleb128(out: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let mut byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+fn push_sleb128(out: &mut Vec<u8>, mut value: i64) {
+    loop {
+        let byte = (value as u8) & 0x7f;
+        let sign_bit_set = (byte & 0x40) != 0;
+        value >>= 7;
+        let done = (value == 0 && !sign_bit_set) || (value == -1 && sign_bit_set);
+        out.push(if done { byte } else { byte | 0x80 });
+        if done {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_uleb(bytes: &[u8], i: &mut usize) -> u64 {
+        let mut shift = 0u32;
+        let mut out = 0u64;
+        loop {
+            let byte = bytes[*i];
+            *i += 1;
+            out |= ((byte & 0x7f) as u64) << shift;
+            if (byte & 0x80) == 0 {
+                return out;
+            }
+            shift += 7;
+        }
+    }
+
+    fn parse_sleb(bytes: &[u8], i: &mut usize) -> i64 {
+        let mut shift = 0u32;
+        let mut out = 0i64;
+        let mut byte;
+        loop {
+            byte = bytes[*i];
+            *i += 1;
+            out |= ((byte & 0x7f) as i64) << shift;
+            shift += 7;
+            if (byte & 0x80) == 0 {
+                break;
+            }
+        }
+        if shift < 64 && (byte & 0x40) != 0 {
+            out |= !0i64 << shift;
+        }
+        out
+    }
+
+    fn parse_debug_line_rows(section: &[u8]) -> Vec<(u64, i64)> {
+        let unit_length = u32::from_le_bytes(section[0..4].try_into().unwrap()) as usize;
+        let version = u16::from_le_bytes(section[4..6].try_into().unwrap());
+        assert_eq!(version, 4);
+        let header_length = u32::from_le_bytes(section[6..10].try_into().unwrap()) as usize;
+        let mut program_i = 10 + header_length;
+        assert_eq!(section.len(), 4 + unit_length);
+
+        let mut rows = Vec::new();
+        let mut address = 0u64;
+        let mut line = 1i64;
+
+        while program_i < section.len() {
+            let opcode = section[program_i];
+            program_i += 1;
+            match opcode {
+                0 => {
+                    let len = parse_uleb(section, &mut program_i) as usize;
+                    let sub = section[program_i];
+                    program_i += 1;
+                    match sub {
+                        DW_LNE_SET_ADDRESS => {
+                            assert_eq!(len, 9);
+                            address = u64::from_le_bytes(
+                                section[program_i..program_i + 8].try_into().unwrap(),
+                            );
+                            program_i += 8;
+                        }
+                        DW_LNE_END_SEQUENCE => {
+                            break;
+                        }
+                        _ => panic!("unexpected extended opcode {sub}"),
+                    }
+                }
+                DW_LNS_ADVANCE_PC => {
+                    address += parse_uleb(section, &mut program_i);
+                }
+                DW_LNS_ADVANCE_LINE => {
+                    line += parse_sleb(section, &mut program_i);
+                }
+                DW_LNS_COPY => rows.push((address, line)),
+                other => panic!("unexpected standard opcode {other}"),
+            }
+        }
+
+        rows
+    }
+
+    #[test]
+    fn debug_line_v4_header_has_max_ops_field() {
+        let section = build_debug_line_section(0x3000, 0, &[], "decoder.ra", None).unwrap();
+        // unit_length (4), version (2), header_length (4), then header body.
+        assert_eq!(u16::from_le_bytes(section[4..6].try_into().unwrap()), 4);
+        assert_eq!(section[10], MIN_INSN_LEN);
+        assert_eq!(section[11], MAX_OPS_PER_INSN);
+        assert_eq!(section[12], DEFAULT_IS_STMT);
+    }
+
+    #[test]
+    fn debug_line_rows_match_source_map() {
+        let section = build_debug_line_section(
+            0x1000,
+            12,
+            &[(0, 0), (4, 3), (9, 7)],
+            "decoder.ra",
+            Some("jit"),
+        )
+        .unwrap();
+
+        let rows = parse_debug_line_rows(&section);
+        assert_eq!(rows, vec![(0x1000, 1), (0x1004, 4), (0x1009, 8)]);
+    }
+
+    #[test]
+    fn debug_line_allows_empty_source_map() {
+        let section = build_debug_line_section(0x2000, 5, &[], "decoder.ra", None).unwrap();
+        let rows = parse_debug_line_rows(&section);
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn rejects_invalid_source_map_and_inputs() {
+        let err = build_debug_line_section(0, 8, &[(4, 1), (4, 2)], "f", None).unwrap_err();
+        assert!(matches!(
+            err,
+            DwarfPrepError::SourceMapNotStrictlyIncreasing {
+                previous_offset: 4,
+                next_offset: 4
+            }
+        ));
+
+        let err = build_debug_line_section(0, 7, &[(8, 0)], "f", None).unwrap_err();
+        assert!(matches!(
+            err,
+            DwarfPrepError::SourceOffsetOutOfBounds {
+                offset: 8,
+                code_size: 7
+            }
+        ));
+
+        let err = build_debug_line_section(0, 8, &[], "bad\0file", None).unwrap_err();
+        assert!(matches!(
+            err,
+            DwarfPrepError::InteriorNul { field: "file_name" }
+        ));
+    }
+}

--- a/kajit/src/lib.rs
+++ b/kajit/src/lib.rs
@@ -13,6 +13,7 @@ pub mod backends;
 pub mod ir_parse;
 pub mod ir_passes;
 pub mod jit_debug;
+pub mod jit_dwarf;
 pub mod jit_f64;
 pub mod json;
 pub mod json_intrinsics;


### PR DESCRIPTION
## Summary
- add a new backend-agnostic `jit_dwarf` module that builds minimal DWARF v4 `.debug_line` payloads from `(code_offset, ra_mir_inst_index)` mappings
- add `register_jit_code_with_dwarf` and extend JIT ELF construction to optionally embed `.debug_line`, `.debug_str`, and `.debug_line_str`
- keep existing `register_jit_code` behavior unchanged by delegating with `None`
- add unit tests for DWARF row emission, input validation, DWARF v4 header layout, and ELF section layout with/without debug sections

## Testing
- `cargo nextest run -p kajit jit_dwarf::tests:: jit_debug::tests::`

Part of #157.
