### PR TITLE
Improve JIT DWARF structure and lexical scopes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bench_report/
 .handoffs/
 .playwright-mcp/
 *.v3*
+scripts/__pycache__/

--- a/docs/pipeline-debugging.md
+++ b/docs/pipeline-debugging.md
@@ -547,6 +547,19 @@ The script resolves the concrete test binary via `cargo nextest list`, then laun
 - Passes test args `--exact <test_name> --nocapture`
 - Leaves LLDB interactive (does not auto-run; type `run` yourself)
 
+For scripted variable-availability checks, use:
+
+```bash
+scripts/lldb-check-vars.sh json::bool_true_false \
+  4:v46:unavailable \
+  5:v46:available \
+  5:v47:unlisted
+```
+
+This runs LLDB in batch mode, steps to each requested CFG-MIR line in order, and
+fails if a variable does not match the expected `available` / `unavailable` /
+`listed` / `unlisted` state.
+
 ### How it works
 
 When `KAJIT_DEBUG=1`:
@@ -565,6 +578,7 @@ That helper gives you LLDB commands keyed by the same CFG-MIR line numbers as DW
 - `kajit-bytes [count]` — read bytes at `input_ptr` as hex plus printable ASCII
 - `kajit-text [count]` — read bytes at `input_ptr` as printable text
 - `kajit-break [regex]` — set a breakpoint on registered JIT decode code
+- `kajit-listed-vars` — print local names visible in the current lexical scope
 - `kajit-here` — print interpreter reference for the current JIT source line
 - `kajit-list` — list available reference lines, or dump one explicit line
 - `kajit-step` — `thread step-over`, then print interpreter reference for the new line
@@ -644,6 +658,7 @@ When LLDB stops at `__jit_debug_register_code`, the JIT code has just been regis
 | `kajit/src/jit_debug.rs` | GDB JIT interface: builds in-memory ELF, registers with debugger, writes perf map |
 | `kajit/src/compiler.rs` | Glue: `build_dwarf_from_source_map()` converts backend source maps to DWARF |
 | `scripts/lldb-test.sh` | Standalone LLDB launcher for one exact test |
+| `scripts/lldb-check-vars.sh` | Batch LLDB checker for per-line variable availability |
 | `scripts/kajit_lldb_side_by_side.py` | LLDB helper commands that map current DWARF line back to interpreter reference |
 | `/tmp/kajit-debug/*.cfg-mir` | Generated listing files (one per JIT-compiled type) |
 | `/tmp/perf-<pid>.map` | perf sampling map (always written, even without `KAJIT_DEBUG`) |

--- a/kajit/src/backends/aarch64/mod.rs
+++ b/kajit/src/backends/aarch64/mod.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 
 use crate::arch::{BASE_FRAME, EmitCtx};
 use crate::ir::Width;
-use crate::ir_backend::LinearBackendResult;
+use crate::ir_backend::{
+    BackendCodeRange, BackendDebugInfo, BackendOpDebugInfo, LinearBackendResult,
+};
 use crate::linearize::{BinOpKind, LinearOp, UnaryOpKind};
 use crate::recipe::{Op, Recipe};
 use crate::regalloc_engine::{AllocatedCfgProgram, cfg_mir};
@@ -62,6 +64,7 @@ pub(crate) struct Lowerer {
     pub(crate) apply_regalloc_edits: bool,
     pub(crate) no_edit_edge_tmp_base: u32,
     pub(crate) edge_args_by_lambda: BTreeMap<u32, BTreeMap<cfg_mir::EdgeId, Vec<cfg_mir::EdgeArg>>>,
+    pub(crate) backend_debug_info: BackendDebugInfo,
 }
 
 #[derive(Clone, Copy)]
@@ -384,7 +387,30 @@ impl Lowerer {
             apply_regalloc_edits,
             no_edit_edge_tmp_base,
             edge_args_by_lambda,
+            backend_debug_info: BackendDebugInfo::default(),
         }
+    }
+
+    fn record_debug_op_range(
+        &mut self,
+        lambda_id: u32,
+        op_id: cfg_mir::OpId,
+        line: u32,
+        start: u32,
+        end: u32,
+    ) {
+        if end <= start {
+            return;
+        }
+        self.backend_debug_info.op_infos.push(BackendOpDebugInfo {
+            lambda_id,
+            op_id,
+            line,
+            code_ranges: vec![BackendCodeRange {
+                start_offset: start,
+                end_offset: end,
+            }],
+        });
     }
 
     pub(super) fn slot_off(&self, s: crate::ir::SlotId) -> u32 {
@@ -817,6 +843,7 @@ impl Lowerer {
                         self.current_inst_allocs =
                             Some(self.canonical_allocs_for_operands(&inst.operands));
                     }
+                    let start_offset = self.ectx.emit.current_offset();
                     if self.apply_regalloc_edits {
                         self.apply_regalloc_edits(op_id, InstPosition::Before);
                     }
@@ -824,6 +851,8 @@ impl Lowerer {
                     if self.apply_regalloc_edits {
                         self.apply_regalloc_edits(op_id, InstPosition::After);
                     }
+                    let end_offset = self.ectx.emit.current_offset();
+                    self.record_debug_op_range(lambda_id, op_id, line, start_offset, end_offset);
                     self.current_inst_allocs = None;
                     self.current_op_id = None;
                 }
@@ -839,7 +868,10 @@ impl Lowerer {
                     column: 0,
                 });
                 let next_block = func.blocks.get(block_index + 1);
+                let start_offset = self.ectx.emit.current_offset();
                 self.emit_terminator(func, block, next_block, term_op);
+                let end_offset = self.ectx.emit.current_offset();
+                self.record_debug_op_range(lambda_id, term_op, line, start_offset, end_offset);
             }
 
             self.flush_all_vregs();
@@ -860,6 +892,7 @@ impl Lowerer {
             buf,
             entry,
             source_map,
+            backend_debug_info: Some(self.backend_debug_info),
         }
     }
 }

--- a/kajit/src/backends/x86_64/mod.rs
+++ b/kajit/src/backends/x86_64/mod.rs
@@ -6,7 +6,9 @@ use std::collections::BTreeMap;
 
 use crate::arch::{BASE_FRAME, EmitCtx};
 use crate::ir::Width;
-use crate::ir_backend::LinearBackendResult;
+use crate::ir_backend::{
+    BackendCodeRange, BackendDebugInfo, BackendOpDebugInfo, LinearBackendResult,
+};
 use crate::linearize::{BinOpKind, LinearOp, UnaryOpKind};
 use crate::recipe::{Op, Recipe};
 use crate::regalloc_engine::{AllocatedCfgProgram, cfg_mir};
@@ -62,6 +64,7 @@ pub(crate) struct Lowerer {
     pub(crate) edge_trampolines: Vec<EdgeTrampoline>,
     pub(crate) current_inst_allocs: Option<Vec<Allocation>>,
     pub(crate) parallel_move_tmp_base: u32,
+    pub(crate) backend_debug_info: BackendDebugInfo,
 }
 
 #[derive(Clone, Copy)]
@@ -254,7 +257,30 @@ impl Lowerer {
             edge_trampolines: Vec::new(),
             current_inst_allocs: None,
             parallel_move_tmp_base,
+            backend_debug_info: BackendDebugInfo::default(),
         }
+    }
+
+    fn record_debug_op_range(
+        &mut self,
+        lambda_id: u32,
+        op_id: cfg_mir::OpId,
+        line: u32,
+        start: u32,
+        end: u32,
+    ) {
+        if end <= start {
+            return;
+        }
+        self.backend_debug_info.op_infos.push(BackendOpDebugInfo {
+            lambda_id,
+            op_id,
+            line,
+            code_ranges: vec![BackendCodeRange {
+                start_offset: start,
+                end_offset: end,
+            }],
+        });
     }
 
     pub(super) fn slot_off(&self, s: crate::ir::SlotId) -> u32 {
@@ -586,9 +612,12 @@ impl Lowerer {
                         .get(&lambda_id)
                         .and_then(|by_lambda| by_lambda.get(&op_id))
                         .cloned();
+                    let start_offset = self.ectx.emit.current_offset();
                     self.apply_regalloc_edits(op_id, InstPosition::Before);
                     self.emit_inst(&inst.op);
                     self.apply_regalloc_edits(op_id, InstPosition::After);
+                    let end_offset = self.ectx.emit.current_offset();
+                    self.record_debug_op_range(lambda_id, op_id, line, start_offset, end_offset);
                     self.current_inst_allocs = None;
                 }
 
@@ -603,7 +632,10 @@ impl Lowerer {
                     column: 0,
                 });
                 let next_block = func.blocks.get(block_index + 1);
+                let start_offset = self.ectx.emit.current_offset();
                 self.emit_terminator(func, block, next_block, term_op);
+                let end_offset = self.ectx.emit.current_offset();
+                self.record_debug_op_range(lambda_id, term_op, line, start_offset, end_offset);
             }
 
             self.flush_all_vregs();
@@ -624,6 +656,7 @@ impl Lowerer {
             buf,
             entry,
             source_map,
+            backend_debug_info: Some(self.backend_debug_info),
         }
     }
 }

--- a/kajit/src/compiler.rs
+++ b/kajit/src/compiler.rs
@@ -79,13 +79,15 @@ fn materialize_backend_result(
     kajit_emit::aarch64::FinalizedEmission,
     usize,
     Option<kajit_emit::SourceMap>,
+    Option<crate::ir_backend::BackendDebugInfo>,
 ) {
     let crate::ir_backend::LinearBackendResult {
         buf,
         entry,
         source_map,
+        backend_debug_info,
     } = result;
-    (buf, entry as usize, source_map)
+    (buf, entry as usize, source_map, backend_debug_info)
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -95,13 +97,15 @@ fn materialize_backend_result(
     kajit_emit::x64::FinalizedEmission,
     usize,
     Option<kajit_emit::SourceMap>,
+    Option<crate::ir_backend::BackendDebugInfo>,
 ) {
     let crate::ir_backend::LinearBackendResult {
         buf,
         entry,
         source_map,
+        backend_debug_info,
     } = result;
-    (buf, entry as usize, source_map)
+    (buf, entry as usize, source_map, backend_debug_info)
 }
 
 fn jit_debug_enabled() -> bool {
@@ -209,37 +213,39 @@ fn jit_dwarf_target_arch() -> crate::jit_dwarf::DwarfTargetArch {
     }
 }
 
-fn build_dwarf_from_source_map(
+fn build_jit_debug_info_from_source_map(
     code_ptr: *const u8,
     code_len: usize,
     source_map: Option<&kajit_emit::SourceMap>,
     listing_path: &Path,
-    subprogram_name: &str,
-    variables: &[crate::jit_dwarf::DwarfVariable],
-    target_arch: crate::jit_dwarf::DwarfTargetArch,
-) -> Option<crate::jit_dwarf::JitDwarfSections> {
+    subprogram: crate::jit_dwarf::JitDebugSubprogram,
+) -> Option<crate::jit_dwarf::JitDebugInfo> {
     let source_map = source_map?;
-    let mut dwarf_map = Vec::<(u32, u32)>::new();
-    for entry in source_map {
-        if entry.location.line == 0 {
-            continue;
-        }
-        dwarf_map.push((entry.offset, entry.location.line.saturating_sub(1)));
-    }
+    let file_name = listing_path.file_name()?.to_str()?.to_owned();
+    let directory = listing_path
+        .parent()
+        .and_then(Path::to_str)
+        .map(str::to_owned);
+    let rows = source_map
+        .iter()
+        .filter(|entry| entry.location.line != 0)
+        .map(|entry| crate::jit_dwarf::JitDebugLineRow {
+            code_offset: entry.offset,
+            line: entry.location.line,
+        })
+        .collect();
 
-    let file_name = listing_path.file_name()?.to_str()?;
-    let directory = listing_path.parent().and_then(Path::to_str);
-    crate::jit_dwarf::build_jit_dwarf_sections_with_variables(
-        target_arch,
-        code_ptr as u64,
-        code_len as u64,
-        &dwarf_map,
-        file_name,
-        directory,
-        subprogram_name,
-        variables,
-    )
-    .ok()
+    Some(crate::jit_dwarf::JitDebugInfo {
+        target_arch: jit_dwarf_target_arch(),
+        code_address: code_ptr as u64,
+        code_size: code_len as u64,
+        line_table: crate::jit_dwarf::JitDebugLineTable {
+            file_name,
+            directory,
+            rows,
+        },
+        subprogram,
+    })
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -305,62 +311,6 @@ fn deser_dwarf_variables(
     .collect()
 }
 
-fn cfg_dwarf_line_by_op(
-    program: &crate::regalloc_engine::cfg_mir::Program,
-) -> BTreeMap<(u32, crate::regalloc_engine::cfg_mir::OpId), u32> {
-    let mut line_by_lambda_op =
-        BTreeMap::<(u32, crate::regalloc_engine::cfg_mir::OpId), u32>::new();
-    let mut next_line = 1u32;
-    for func in &program.funcs {
-        let lambda_id = func.lambda_id.index() as u32;
-        for block in &func.blocks {
-            for inst_id in &block.insts {
-                line_by_lambda_op.insert(
-                    (
-                        lambda_id,
-                        crate::regalloc_engine::cfg_mir::OpId::Inst(*inst_id),
-                    ),
-                    next_line,
-                );
-                next_line += 1;
-            }
-            line_by_lambda_op.insert(
-                (
-                    lambda_id,
-                    crate::regalloc_engine::cfg_mir::OpId::Term(block.term),
-                ),
-                next_line,
-            );
-            next_line += 1;
-        }
-    }
-    line_by_lambda_op
-}
-
-fn line_ranges_from_source_map(
-    code_ptr: *const u8,
-    code_len: usize,
-    source_map: &kajit_emit::SourceMap,
-) -> BTreeMap<u32, Vec<(u64, u64)>> {
-    let mut by_line = BTreeMap::<u32, Vec<(u64, u64)>>::new();
-    for (index, entry) in source_map.iter().enumerate() {
-        let line = entry.location.line;
-        if line == 0 {
-            continue;
-        }
-        let start = code_ptr as u64 + entry.offset as u64;
-        let end_offset = source_map
-            .get(index + 1)
-            .map(|next| next.offset as usize)
-            .unwrap_or(code_len);
-        let end = code_ptr as u64 + end_offset as u64;
-        if end > start {
-            by_line.entry(line).or_default().push((start, end));
-        }
-    }
-    by_line
-}
-
 #[cfg(target_arch = "aarch64")]
 fn aarch64_regalloc_extra_saved_pairs(alloc: &crate::regalloc_engine::AllocatedCfgProgram) -> u32 {
     let mut max_pair = None::<u32>;
@@ -405,6 +355,59 @@ fn aarch64_regalloc_extra_saved_pairs(alloc: &crate::regalloc_engine::AllocatedC
     max_pair.map_or(0, |pair| pair + 1)
 }
 
+fn find_cfg_alloc_for_vreg_in_op(
+    alloc_func: &crate::regalloc_engine::AllocatedCfgFunction,
+    op_id: crate::regalloc_engine::cfg_mir::OpId,
+    vreg: crate::ir::VReg,
+    preferred_kind: Option<crate::regalloc_engine::cfg_mir::OperandKind>,
+) -> Option<regalloc2::Allocation> {
+    let operands = alloc_func.op_operands.get(&op_id)?;
+    let allocs = alloc_func.op_allocs.get(&op_id)?;
+    for ((operand_vreg, operand_kind), alloc) in operands.iter().zip(allocs.iter().copied()) {
+        if *operand_vreg != vreg {
+            continue;
+        }
+        if preferred_kind.is_none_or(|kind| *operand_kind == kind) {
+            return Some(alloc);
+        }
+    }
+    None
+}
+
+fn infer_cfg_block_param_entry_alloc(
+    _func: &crate::regalloc_engine::cfg_mir::Function,
+    alloc_func: &crate::regalloc_engine::AllocatedCfgFunction,
+    block: &crate::regalloc_engine::cfg_mir::Block,
+    param: crate::ir::VReg,
+) -> Option<regalloc2::Allocation> {
+    for inst_id in &block.insts {
+        let op_id = crate::regalloc_engine::cfg_mir::OpId::Inst(*inst_id);
+        if let Some(alloc) = find_cfg_alloc_for_vreg_in_op(
+            alloc_func,
+            op_id,
+            param,
+            Some(crate::regalloc_engine::cfg_mir::OperandKind::Use),
+        ) {
+            return Some(alloc);
+        }
+        if let Some(alloc) = find_cfg_alloc_for_vreg_in_op(
+            alloc_func,
+            op_id,
+            param,
+            Some(crate::regalloc_engine::cfg_mir::OperandKind::Def),
+        ) {
+            return Some(alloc);
+        }
+    }
+    let term_op = crate::regalloc_engine::cfg_mir::OpId::Term(block.term);
+    find_cfg_alloc_for_vreg_in_op(
+        alloc_func,
+        term_op,
+        param,
+        Some(crate::regalloc_engine::cfg_mir::OperandKind::Use),
+    )
+}
+
 fn dwarf_expr_for_cfg_allocation(
     program: &crate::regalloc_engine::cfg_mir::Program,
     alloc: &crate::regalloc_engine::AllocatedCfgProgram,
@@ -444,20 +447,43 @@ fn dwarf_expr_for_cfg_allocation(
     None
 }
 
+fn backend_op_ranges_by_op(
+    backend_debug_info: &crate::ir_backend::BackendDebugInfo,
+    code_ptr: *const u8,
+) -> BTreeMap<(u32, crate::regalloc_engine::cfg_mir::OpId), Vec<(u64, u64)>> {
+    backend_debug_info
+        .op_infos
+        .iter()
+        .map(|op_info| {
+            (
+                (op_info.lambda_id, op_info.op_id),
+                op_info
+                    .code_ranges
+                    .iter()
+                    .map(|range| {
+                        (
+                            code_ptr as u64 + range.start_offset as u64,
+                            code_ptr as u64 + range.end_offset as u64,
+                        )
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        })
+        .collect()
+}
+
 fn cfg_value_dwarf_variables(
     program: &crate::regalloc_engine::cfg_mir::Program,
     alloc: &crate::regalloc_engine::AllocatedCfgProgram,
-    source_map: Option<&kajit_emit::SourceMap>,
+    backend_debug_info: Option<&crate::ir_backend::BackendDebugInfo>,
     code_ptr: *const u8,
-    code_len: usize,
     target_arch: crate::jit_dwarf::DwarfTargetArch,
     apply_regalloc_edits: bool,
 ) -> Vec<crate::jit_dwarf::DwarfVariable> {
-    let Some(source_map) = source_map else {
+    let Some(backend_debug_info) = backend_debug_info else {
         return Vec::new();
     };
-    let line_ranges = line_ranges_from_source_map(code_ptr, code_len, source_map);
-    let line_by_op = cfg_dwarf_line_by_op(program);
+    let op_ranges = backend_op_ranges_by_op(backend_debug_info, code_ptr);
     let alloc_func_by_lambda = alloc
         .functions
         .iter()
@@ -472,16 +498,54 @@ fn cfg_value_dwarf_variables(
         };
         let lambda_key = func.lambda_id.index() as u32;
         for block in &func.blocks {
-            let mut live_locations = BTreeMap::<crate::ir::VReg, regalloc2::Allocation>::new();
+            let mut remaining_uses = BTreeMap::<crate::ir::VReg, usize>::new();
             for inst_id in &block.insts {
                 let op_id = crate::regalloc_engine::cfg_mir::OpId::Inst(*inst_id);
-                let Some(line) = line_by_op.get(&(lambda_key, op_id)).copied() else {
+                if let Some(operand_pairs) = alloc_func.op_operands.get(&op_id) {
+                    for (vreg, operand_kind) in operand_pairs {
+                        if *operand_kind == crate::regalloc_engine::cfg_mir::OperandKind::Use {
+                            *remaining_uses.entry(*vreg).or_default() += 1;
+                        }
+                    }
+                }
+            }
+            let term_op = crate::regalloc_engine::cfg_mir::OpId::Term(block.term);
+            if let Some(operand_pairs) = alloc_func.op_operands.get(&term_op) {
+                for (vreg, operand_kind) in operand_pairs {
+                    if *operand_kind == crate::regalloc_engine::cfg_mir::OperandKind::Use {
+                        *remaining_uses.entry(*vreg).or_default() += 1;
+                    }
+                }
+            }
+            for &edge_id in &block.succs {
+                let Some(edge) = func.edges.get(edge_id.index()) else {
                     continue;
                 };
-                let Some(op_ranges) = line_ranges.get(&line) else {
+                for edge_arg in &edge.args {
+                    *remaining_uses.entry(edge_arg.source).or_default() += 1;
+                }
+            }
+
+            let mut live_locations = BTreeMap::<crate::ir::VReg, regalloc2::Allocation>::new();
+            for &param in &block.params {
+                if remaining_uses.get(&param).copied().unwrap_or(0) == 0 {
+                    continue;
+                }
+                let Some(allocation) =
+                    infer_cfg_block_param_entry_alloc(func, alloc_func, block, param)
+                else {
                     continue;
                 };
-                let mut defs_for_op = Vec::<(crate::ir::VReg, regalloc2::Allocation)>::new();
+                live_locations.insert(param, allocation);
+            }
+
+            for inst_id in &block.insts {
+                let op_id = crate::regalloc_engine::cfg_mir::OpId::Inst(*inst_id);
+                let Some(op_ranges) = op_ranges.get(&(lambda_key, op_id)) else {
+                    continue;
+                };
+                let mut used_now = Vec::<crate::ir::VReg>::new();
+                let mut defs_after = Vec::<(crate::ir::VReg, regalloc2::Allocation)>::new();
                 if let (Some(operand_pairs), Some(operand_allocs)) = (
                     alloc_func.op_operands.get(&op_id),
                     alloc_func.op_allocs.get(&op_id),
@@ -489,18 +553,22 @@ fn cfg_value_dwarf_variables(
                     for ((vreg, operand_kind), allocation) in
                         operand_pairs.iter().zip(operand_allocs.iter().copied())
                     {
-                        if *operand_kind != crate::regalloc_engine::cfg_mir::OperandKind::Def {
-                            continue;
+                        match operand_kind {
+                            crate::regalloc_engine::cfg_mir::OperandKind::Use => {
+                                live_locations.insert(*vreg, allocation);
+                                used_now.push(*vreg);
+                            }
+                            crate::regalloc_engine::cfg_mir::OperandKind::Def => {
+                                defs_after.push((*vreg, allocation));
+                            }
                         }
-                        defs_for_op.push((*vreg, allocation));
                     }
                 }
 
-                for (vreg, allocation) in defs_for_op {
-                    live_locations.insert(vreg, allocation);
-                }
-
                 for (vreg, allocation) in &live_locations {
+                    if remaining_uses.get(vreg).copied().unwrap_or(0) == 0 {
+                        continue;
+                    }
                     let Some(expr) = dwarf_expr_for_cfg_allocation(
                         program,
                         alloc,
@@ -519,16 +587,42 @@ fn cfg_value_dwarf_variables(
                         });
                     }
                 }
+
+                for vreg in used_now {
+                    if let Some(count) = remaining_uses.get_mut(&vreg) {
+                        *count = count.saturating_sub(1);
+                    }
+                }
+                live_locations.retain(|vreg, _| remaining_uses.get(vreg).copied().unwrap_or(0) > 0);
+                for (vreg, allocation) in defs_after {
+                    if remaining_uses.get(&vreg).copied().unwrap_or(0) > 0 {
+                        live_locations.insert(vreg, allocation);
+                    }
+                }
             }
 
-            let term_op = crate::regalloc_engine::cfg_mir::OpId::Term(block.term);
-            let Some(line) = line_by_op.get(&(lambda_key, term_op)).copied() else {
+            let Some(op_ranges) = op_ranges.get(&(lambda_key, term_op)) else {
                 continue;
             };
-            let Some(op_ranges) = line_ranges.get(&line) else {
-                continue;
-            };
+            let mut used_now = Vec::<crate::ir::VReg>::new();
+            if let (Some(operand_pairs), Some(operand_allocs)) = (
+                alloc_func.op_operands.get(&term_op),
+                alloc_func.op_allocs.get(&term_op),
+            ) {
+                for ((vreg, operand_kind), allocation) in
+                    operand_pairs.iter().zip(operand_allocs.iter().copied())
+                {
+                    if *operand_kind != crate::regalloc_engine::cfg_mir::OperandKind::Use {
+                        continue;
+                    }
+                    live_locations.insert(*vreg, allocation);
+                    used_now.push(*vreg);
+                }
+            }
             for (vreg, allocation) in &live_locations {
+                if remaining_uses.get(vreg).copied().unwrap_or(0) == 0 {
+                    continue;
+                }
                 let Some(expr) = dwarf_expr_for_cfg_allocation(
                     program,
                     alloc,
@@ -545,6 +639,11 @@ fn cfg_value_dwarf_variables(
                         end: *end,
                         expression: expr.clone(),
                     });
+                }
+            }
+            for vreg in used_now {
+                if let Some(count) = remaining_uses.get_mut(&vreg) {
+                    *count = count.saturating_sub(1);
                 }
             }
         }
@@ -581,23 +680,133 @@ fn cfg_value_dwarf_variables(
 fn cfg_mir_dwarf_variables(
     program: &crate::regalloc_engine::cfg_mir::Program,
     alloc: &crate::regalloc_engine::AllocatedCfgProgram,
-    source_map: Option<&kajit_emit::SourceMap>,
+    backend_debug_info: Option<&crate::ir_backend::BackendDebugInfo>,
     code_ptr: *const u8,
-    code_len: usize,
     target_arch: crate::jit_dwarf::DwarfTargetArch,
     apply_regalloc_edits: bool,
-) -> Vec<crate::jit_dwarf::DwarfVariable> {
+) -> crate::jit_dwarf::JitDebugSubprogram {
     let mut variables = deser_dwarf_variables(target_arch);
-    variables.extend(cfg_value_dwarf_variables(
+    let cfg_variables = cfg_value_dwarf_variables(
         program,
         alloc,
-        source_map,
+        backend_debug_info,
         code_ptr,
-        code_len,
         target_arch,
         apply_regalloc_edits,
-    ));
-    variables
+    );
+    let (unscoped_cfg_variables, lexical_blocks) =
+        cfg_mir_lexical_blocks(program, backend_debug_info, code_ptr, cfg_variables);
+    variables.extend(unscoped_cfg_variables);
+    crate::jit_dwarf::JitDebugSubprogram {
+        name: String::new(),
+        frame_base_expression: crate::jit_dwarf::expr_breg(
+            crate::jit_dwarf::frame_base_register(target_arch),
+            0,
+        ),
+        variables,
+        lexical_blocks,
+    }
+}
+
+fn cfg_mir_lexical_blocks(
+    program: &crate::regalloc_engine::cfg_mir::Program,
+    backend_debug_info: Option<&crate::ir_backend::BackendDebugInfo>,
+    code_ptr: *const u8,
+    cfg_variables: Vec<crate::jit_dwarf::DwarfVariable>,
+) -> (
+    Vec<crate::jit_dwarf::DwarfVariable>,
+    Vec<crate::jit_dwarf::JitDebugLexicalBlock>,
+) {
+    let Some(backend_debug_info) = backend_debug_info else {
+        return (cfg_variables, Vec::new());
+    };
+    let op_ranges = backend_op_ranges_by_op(backend_debug_info, code_ptr);
+    let mut block_ranges =
+        BTreeMap::<(u32, crate::regalloc_engine::cfg_mir::BlockId), (u64, u64)>::new();
+    for func in &program.funcs {
+        let lambda_key = func.lambda_id.index() as u32;
+        for block in &func.blocks {
+            let mut low_pc = u64::MAX;
+            let mut high_pc = 0u64;
+            for inst_id in &block.insts {
+                let op_id = crate::regalloc_engine::cfg_mir::OpId::Inst(*inst_id);
+                if let Some(ranges) = op_ranges.get(&(lambda_key, op_id)) {
+                    for (start, end) in ranges {
+                        if end <= start {
+                            continue;
+                        }
+                        low_pc = low_pc.min(*start);
+                        high_pc = high_pc.max(*end);
+                    }
+                }
+            }
+            let term_op = crate::regalloc_engine::cfg_mir::OpId::Term(block.term);
+            if let Some(ranges) = op_ranges.get(&(lambda_key, term_op)) {
+                for (start, end) in ranges {
+                    if end <= start {
+                        continue;
+                    }
+                    low_pc = low_pc.min(*start);
+                    high_pc = high_pc.max(*end);
+                }
+            }
+            if low_pc < high_pc {
+                block_ranges.insert((lambda_key, block.id), (low_pc, high_pc));
+            }
+        }
+    }
+
+    let mut vars_by_block = BTreeMap::<
+        (u32, crate::regalloc_engine::cfg_mir::BlockId),
+        Vec<crate::jit_dwarf::DwarfVariable>,
+    >::new();
+    let mut unscoped_variables = Vec::new();
+    for variable in cfg_variables {
+        let crate::jit_dwarf::DwarfVariableLocation::List(locations) = &variable.location else {
+            unscoped_variables.push(variable);
+            continue;
+        };
+        let Some((lambda_key, block_id)) = block_ranges
+            .iter()
+            .filter_map(|(&(lambda_key, block_id), &(low_pc, high_pc))| {
+                locations
+                    .iter()
+                    .all(|location| location.start >= low_pc && location.end <= high_pc)
+                    .then_some((high_pc.saturating_sub(low_pc), lambda_key, block_id))
+            })
+            .min_by_key(|(span, lambda_key, block_id)| (*span, *lambda_key, block_id.index()))
+            .map(|(_, lambda_key, block_id)| (lambda_key, block_id))
+        else {
+            unscoped_variables.push(variable);
+            continue;
+        };
+        vars_by_block
+            .entry((lambda_key, block_id))
+            .or_default()
+            .push(variable);
+    }
+
+    let mut lexical_blocks = Vec::new();
+    for func in &program.funcs {
+        let lambda_key = func.lambda_id.index() as u32;
+        for block in &func.blocks {
+            let Some((low_pc, high_pc)) = block_ranges.get(&(lambda_key, block.id)).copied() else {
+                continue;
+            };
+            let Some(mut variables) = vars_by_block.remove(&(lambda_key, block.id)) else {
+                continue;
+            };
+            variables.sort_by(|lhs, rhs| lhs.name.cmp(&rhs.name));
+            lexical_blocks.push(crate::jit_dwarf::JitDebugLexicalBlock {
+                low_pc,
+                high_pc,
+                variables,
+                lexical_blocks: Vec::new(),
+            });
+        }
+    }
+    lexical_blocks.sort_by_key(|block| (block.low_pc, block.high_pc));
+    (unscoped_variables, lexical_blocks)
 }
 
 // r[impl compiler.walk]
@@ -1639,7 +1848,7 @@ fn compile_linear_ir_decoder_with_options(
         no_regalloc_alloc_for_cfg_program(&cfg_program)
     };
 
-    let (buf, entry, source_map) = {
+    let (buf, entry, source_map, backend_debug_info) = {
         let result = crate::ir_backend::compile_linear_ir_with_alloc_and_mode(
             ir,
             &cfg_program,
@@ -1691,25 +1900,24 @@ fn compile_linear_ir_decoder_with_options(
     };
     let registration = if jit_debug {
         let listing_path = write_cfg_mir_listing_file(&root_display_name, &listing.text);
-        let dwarf_variables = cfg_mir_dwarf_variables(
+        let mut debug_subprogram = cfg_mir_dwarf_variables(
             &cfg_program,
             &regalloc_alloc,
-            source_map.as_ref(),
+            backend_debug_info.as_ref(),
             buf.code_ptr(),
-            buf.len(),
             jit_dwarf_target_arch(),
             apply_regalloc_edits,
         );
+        debug_subprogram.name = root_display_name.clone();
         let dwarf = listing_path.as_deref().and_then(|path| {
-            build_dwarf_from_source_map(
+            let debug_info = build_jit_debug_info_from_source_map(
                 buf.code_ptr(),
                 buf.len(),
                 source_map.as_ref(),
                 path,
-                &root_display_name,
-                &dwarf_variables,
-                jit_dwarf_target_arch(),
-            )
+                debug_subprogram.clone(),
+            )?;
+            crate::jit_dwarf::build_jit_dwarf_sections_from_debug_info(&debug_info).ok()
         });
         crate::jit_debug::register_jit_code_with_dwarf(
             buf.code_ptr(),
@@ -1755,7 +1963,7 @@ fn compile_cfg_mir_decoder_with_options(
         vreg_count: cfg_program.vreg_count,
         slot_count: cfg_program.slot_count,
     };
-    let (buf, entry, source_map) = {
+    let (buf, entry, source_map, backend_debug_info) = {
         let result = crate::ir_backend::compile_linear_ir_with_alloc_and_mode(
             &shim_linear,
             cfg_program,
@@ -1777,25 +1985,24 @@ fn compile_cfg_mir_decoder_with_options(
     };
     let registration = if jit_debug {
         let listing_path = write_cfg_mir_listing_file(&root_display_name, &listing.text);
-        let dwarf_variables = cfg_mir_dwarf_variables(
+        let mut debug_subprogram = cfg_mir_dwarf_variables(
             cfg_program,
             &regalloc_alloc,
-            source_map.as_ref(),
+            backend_debug_info.as_ref(),
             buf.code_ptr(),
-            buf.len(),
             jit_dwarf_target_arch(),
             apply_regalloc_edits,
         );
+        debug_subprogram.name = root_display_name.clone();
         let dwarf = listing_path.as_deref().and_then(|path| {
-            build_dwarf_from_source_map(
+            let debug_info = build_jit_debug_info_from_source_map(
                 buf.code_ptr(),
                 buf.len(),
                 source_map.as_ref(),
                 path,
-                &root_display_name,
-                &dwarf_variables,
-                jit_dwarf_target_arch(),
-            )
+                debug_subprogram.clone(),
+            )?;
+            crate::jit_dwarf::build_jit_dwarf_sections_from_debug_info(&debug_info).ok()
         });
         crate::jit_debug::register_jit_code_with_dwarf(
             buf.code_ptr(),
@@ -1883,16 +2090,24 @@ mod tests {
         std::fs::create_dir_all(listing_path.parent().expect("temp listing dir")).unwrap();
         std::fs::write(&listing_path, "inst0\ninst1\n").unwrap();
 
-        let dwarf = build_dwarf_from_source_map(
+        let debug_info = build_jit_debug_info_from_source_map(
             0x1000 as *const u8,
             32,
             Some(&source_map),
             &listing_path,
-            "kajit::decode::test",
-            &[],
-            jit_dwarf_target_arch(),
+            crate::jit_dwarf::JitDebugSubprogram {
+                name: "kajit::decode::test".to_string(),
+                frame_base_expression: crate::jit_dwarf::expr_breg(
+                    crate::jit_dwarf::frame_base_register(jit_dwarf_target_arch()),
+                    0,
+                ),
+                variables: Vec::new(),
+                lexical_blocks: Vec::new(),
+            },
         )
-        .expect("expected dwarf sections");
+        .expect("expected debug info");
+        let dwarf = crate::jit_dwarf::build_jit_dwarf_sections_from_debug_info(&debug_info)
+            .expect("expected dwarf sections");
         assert!(!dwarf.debug_line.is_empty());
     }
 
@@ -1959,15 +2174,24 @@ mod tests {
                 },
                 crate::regalloc_engine::cfg_mir::Inst {
                     id: inst_id_2,
-                    op: crate::linearize::LinearOp::PeekByte {
+                    op: crate::linearize::LinearOp::Copy {
                         dst: crate::ir::VReg::new(1),
+                        src: v0,
                     },
-                    operands: vec![crate::regalloc_engine::cfg_mir::Operand {
-                        vreg: crate::ir::VReg::new(1),
-                        kind: crate::regalloc_engine::cfg_mir::OperandKind::Def,
-                        class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
-                        fixed: None,
-                    }],
+                    operands: vec![
+                        crate::regalloc_engine::cfg_mir::Operand {
+                            vreg: v0,
+                            kind: crate::regalloc_engine::cfg_mir::OperandKind::Use,
+                            class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                            fixed: None,
+                        },
+                        crate::regalloc_engine::cfg_mir::Operand {
+                            vreg: crate::ir::VReg::new(1),
+                            kind: crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                            class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                            fixed: None,
+                        },
+                    ],
                     clobbers: crate::regalloc_engine::cfg_mir::Clobbers::default(),
                 },
             ],
@@ -1996,7 +2220,13 @@ mod tests {
                 edits: Vec::new(),
                 op_allocs: std::collections::HashMap::from([
                     (op_id, vec![regalloc2::Allocation::reg(reg)]),
-                    (op_id_2, vec![regalloc2::Allocation::reg(reg_2)]),
+                    (
+                        op_id_2,
+                        vec![
+                            regalloc2::Allocation::reg(reg),
+                            regalloc2::Allocation::reg(reg_2),
+                        ],
+                    ),
                 ]),
                 op_operands: std::collections::HashMap::from([
                     (
@@ -2005,60 +2235,67 @@ mod tests {
                     ),
                     (
                         op_id_2,
-                        vec![(
-                            crate::ir::VReg::new(1),
-                            crate::regalloc_engine::cfg_mir::OperandKind::Def,
-                        )],
+                        vec![
+                            (v0, crate::regalloc_engine::cfg_mir::OperandKind::Use),
+                            (
+                                crate::ir::VReg::new(1),
+                                crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                            ),
+                        ],
                     ),
                 ]),
                 edge_edits: Vec::new(),
                 return_result_allocs: Vec::new(),
             }],
         };
-        let source_map = vec![
-            kajit_emit::SourceMapEntry {
-                offset: 0,
-                location: kajit_emit::SourceLocation {
-                    file: 0,
+        let backend_debug_info = crate::ir_backend::BackendDebugInfo {
+            op_infos: vec![
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id,
                     line: 1,
-                    column: 0,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 0,
+                        end_offset: 4,
+                    }],
                 },
-            },
-            kajit_emit::SourceMapEntry {
-                offset: 4,
-                location: kajit_emit::SourceLocation {
-                    file: 0,
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id: op_id_2,
                     line: 2,
-                    column: 0,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 4,
+                        end_offset: 8,
+                    }],
                 },
-            },
-            kajit_emit::SourceMapEntry {
-                offset: 8,
-                location: kajit_emit::SourceLocation {
-                    file: 0,
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id: crate::regalloc_engine::cfg_mir::OpId::Term(term_id),
                     line: 3,
-                    column: 0,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 8,
+                        end_offset: 12,
+                    }],
                 },
-            },
-        ];
+            ],
+        };
 
         let vars = cfg_value_dwarf_variables(
             &program,
             &alloc,
-            Some(&source_map),
+            Some(&backend_debug_info),
             0x1000 as *const u8,
-            12,
             jit_dwarf_target_arch(),
             true,
         );
 
-        assert_eq!(vars.len(), 2);
+        assert_eq!(vars.len(), 1);
         assert_eq!(vars[0].name, "v0");
         match &vars[0].location {
             crate::jit_dwarf::DwarfVariableLocation::List(locations) => {
                 assert_eq!(locations.len(), 1);
-                assert_eq!(locations[0].start, 0x1000);
-                assert_eq!(locations[0].end, 0x100c);
+                assert_eq!(locations[0].start, 0x1004);
+                assert_eq!(locations[0].end, 0x1008);
                 let dwarf_reg = crate::jit_dwarf::dwarf_register_from_hw_encoding(
                     jit_dwarf_target_arch(),
                     reg.hw_enc() as u8,
@@ -2073,5 +2310,347 @@ mod tests {
                 panic!("cfg def vregs should use ranged locations")
             }
         }
+    }
+
+    #[test]
+    fn cfg_value_dwarf_variables_keep_edge_carried_defs_live() {
+        let v0 = crate::ir::VReg::new(0);
+        let v1 = crate::ir::VReg::new(1);
+        let inst_id = crate::regalloc_engine::cfg_mir::InstId::new(0);
+        let inst_id_2 = crate::regalloc_engine::cfg_mir::InstId::new(1);
+        let term_id = crate::regalloc_engine::cfg_mir::TermId::new(0);
+        let return_term_id = crate::regalloc_engine::cfg_mir::TermId::new(1);
+        let entry_block_id = crate::regalloc_engine::cfg_mir::BlockId::new(0);
+        let exit_block_id = crate::regalloc_engine::cfg_mir::BlockId::new(1);
+        let edge_id = crate::regalloc_engine::cfg_mir::EdgeId::new(0);
+        let func = crate::regalloc_engine::cfg_mir::Function {
+            id: crate::regalloc_engine::cfg_mir::FunctionId::new(0),
+            lambda_id: crate::ir::LambdaId::new(0),
+            entry: entry_block_id,
+            data_args: Vec::new(),
+            data_results: Vec::new(),
+            blocks: vec![
+                crate::regalloc_engine::cfg_mir::Block {
+                    id: entry_block_id,
+                    params: Vec::new(),
+                    insts: vec![inst_id, inst_id_2],
+                    term: term_id,
+                    preds: Vec::new(),
+                    succs: vec![edge_id],
+                },
+                crate::regalloc_engine::cfg_mir::Block {
+                    id: exit_block_id,
+                    params: vec![v0],
+                    insts: Vec::new(),
+                    term: return_term_id,
+                    preds: vec![edge_id],
+                    succs: Vec::new(),
+                },
+            ],
+            edges: vec![crate::regalloc_engine::cfg_mir::Edge {
+                id: edge_id,
+                from: entry_block_id,
+                to: exit_block_id,
+                args: vec![crate::regalloc_engine::cfg_mir::EdgeArg {
+                    target: v0,
+                    source: v0,
+                }],
+            }],
+            insts: vec![
+                crate::regalloc_engine::cfg_mir::Inst {
+                    id: inst_id,
+                    op: crate::linearize::LinearOp::Const { dst: v0, value: 7 },
+                    operands: vec![crate::regalloc_engine::cfg_mir::Operand {
+                        vreg: v0,
+                        kind: crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                        class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                        fixed: None,
+                    }],
+                    clobbers: crate::regalloc_engine::cfg_mir::Clobbers::default(),
+                },
+                crate::regalloc_engine::cfg_mir::Inst {
+                    id: inst_id_2,
+                    op: crate::linearize::LinearOp::Const { dst: v1, value: 9 },
+                    operands: vec![crate::regalloc_engine::cfg_mir::Operand {
+                        vreg: v1,
+                        kind: crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                        class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                        fixed: None,
+                    }],
+                    clobbers: crate::regalloc_engine::cfg_mir::Clobbers::default(),
+                },
+            ],
+            terms: vec![
+                crate::regalloc_engine::cfg_mir::Terminator::Branch { edge: edge_id },
+                crate::regalloc_engine::cfg_mir::Terminator::Return,
+            ],
+        };
+        let program = crate::regalloc_engine::cfg_mir::Program {
+            funcs: vec![func],
+            vreg_count: 2,
+            slot_count: 0,
+        };
+        let op_id = crate::regalloc_engine::cfg_mir::OpId::Inst(inst_id);
+        let op_id_2 = crate::regalloc_engine::cfg_mir::OpId::Inst(inst_id_2);
+        let term_op = crate::regalloc_engine::cfg_mir::OpId::Term(term_id);
+        #[cfg(target_arch = "aarch64")]
+        let reg = regalloc2::PReg::new(19, regalloc2::RegClass::Int);
+        #[cfg(target_arch = "x86_64")]
+        let reg = regalloc2::PReg::new(12, regalloc2::RegClass::Int);
+        #[cfg(target_arch = "aarch64")]
+        let reg_2 = regalloc2::PReg::new(20, regalloc2::RegClass::Int);
+        #[cfg(target_arch = "x86_64")]
+        let reg_2 = regalloc2::PReg::new(13, regalloc2::RegClass::Int);
+        let alloc = crate::regalloc_engine::AllocatedCfgProgram {
+            cfg_program: program.clone(),
+            functions: vec![crate::regalloc_engine::AllocatedCfgFunction {
+                lambda_id: crate::ir::LambdaId::new(0),
+                num_spillslots: 0,
+                edits: Vec::new(),
+                op_allocs: std::collections::HashMap::from([
+                    (op_id, vec![regalloc2::Allocation::reg(reg)]),
+                    (op_id_2, vec![regalloc2::Allocation::reg(reg_2)]),
+                ]),
+                op_operands: std::collections::HashMap::from([
+                    (
+                        op_id,
+                        vec![(v0, crate::regalloc_engine::cfg_mir::OperandKind::Def)],
+                    ),
+                    (
+                        op_id_2,
+                        vec![(v1, crate::regalloc_engine::cfg_mir::OperandKind::Def)],
+                    ),
+                    (term_op, Vec::new()),
+                ]),
+                edge_edits: Vec::new(),
+                return_result_allocs: Vec::new(),
+            }],
+        };
+        let backend_debug_info = crate::ir_backend::BackendDebugInfo {
+            op_infos: vec![
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id,
+                    line: 1,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 0,
+                        end_offset: 4,
+                    }],
+                },
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id: op_id_2,
+                    line: 2,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 4,
+                        end_offset: 8,
+                    }],
+                },
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id: term_op,
+                    line: 3,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 8,
+                        end_offset: 12,
+                    }],
+                },
+            ],
+        };
+
+        let vars = cfg_value_dwarf_variables(
+            &program,
+            &alloc,
+            Some(&backend_debug_info),
+            0x1000 as *const u8,
+            jit_dwarf_target_arch(),
+            true,
+        );
+
+        assert_eq!(vars.len(), 1);
+        assert_eq!(vars[0].name, "v0");
+        match &vars[0].location {
+            crate::jit_dwarf::DwarfVariableLocation::List(locations) => {
+                assert_eq!(locations.len(), 1);
+                assert_eq!(locations[0].start, 0x1004);
+                assert_eq!(locations[0].end, 0x100c);
+                let dwarf_reg = crate::jit_dwarf::dwarf_register_from_hw_encoding(
+                    jit_dwarf_target_arch(),
+                    reg.hw_enc() as u8,
+                )
+                .unwrap();
+                assert_eq!(
+                    locations[0].expression,
+                    crate::jit_dwarf::expr_reg(dwarf_reg)
+                );
+            }
+            crate::jit_dwarf::DwarfVariableLocation::Expr(_) => {
+                panic!("cfg edge-carried vregs should use ranged locations")
+            }
+        }
+    }
+
+    #[test]
+    fn cfg_mir_dwarf_variables_place_block_local_vregs_in_lexical_blocks() {
+        let v0 = crate::ir::VReg::new(0);
+        let inst_id = crate::regalloc_engine::cfg_mir::InstId::new(0);
+        let inst_id_2 = crate::regalloc_engine::cfg_mir::InstId::new(1);
+        let term_id = crate::regalloc_engine::cfg_mir::TermId::new(0);
+        let block_id = crate::regalloc_engine::cfg_mir::BlockId::new(0);
+        let func = crate::regalloc_engine::cfg_mir::Function {
+            id: crate::regalloc_engine::cfg_mir::FunctionId::new(0),
+            lambda_id: crate::ir::LambdaId::new(0),
+            entry: block_id,
+            data_args: Vec::new(),
+            data_results: Vec::new(),
+            blocks: vec![crate::regalloc_engine::cfg_mir::Block {
+                id: block_id,
+                params: Vec::new(),
+                insts: vec![inst_id, inst_id_2],
+                term: term_id,
+                preds: Vec::new(),
+                succs: Vec::new(),
+            }],
+            edges: Vec::new(),
+            insts: vec![
+                crate::regalloc_engine::cfg_mir::Inst {
+                    id: inst_id,
+                    op: crate::linearize::LinearOp::Const { dst: v0, value: 7 },
+                    operands: vec![crate::regalloc_engine::cfg_mir::Operand {
+                        vreg: v0,
+                        kind: crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                        class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                        fixed: None,
+                    }],
+                    clobbers: crate::regalloc_engine::cfg_mir::Clobbers::default(),
+                },
+                crate::regalloc_engine::cfg_mir::Inst {
+                    id: inst_id_2,
+                    op: crate::linearize::LinearOp::Copy {
+                        dst: crate::ir::VReg::new(1),
+                        src: v0,
+                    },
+                    operands: vec![
+                        crate::regalloc_engine::cfg_mir::Operand {
+                            vreg: v0,
+                            kind: crate::regalloc_engine::cfg_mir::OperandKind::Use,
+                            class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                            fixed: None,
+                        },
+                        crate::regalloc_engine::cfg_mir::Operand {
+                            vreg: crate::ir::VReg::new(1),
+                            kind: crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                            class: crate::regalloc_engine::cfg_mir::RegClass::Gpr,
+                            fixed: None,
+                        },
+                    ],
+                    clobbers: crate::regalloc_engine::cfg_mir::Clobbers::default(),
+                },
+            ],
+            terms: vec![crate::regalloc_engine::cfg_mir::Terminator::Return],
+        };
+        let program = crate::regalloc_engine::cfg_mir::Program {
+            funcs: vec![func],
+            vreg_count: 2,
+            slot_count: 0,
+        };
+        let op_id = crate::regalloc_engine::cfg_mir::OpId::Inst(inst_id);
+        let op_id_2 = crate::regalloc_engine::cfg_mir::OpId::Inst(inst_id_2);
+        #[cfg(target_arch = "aarch64")]
+        let reg = regalloc2::PReg::new(19, regalloc2::RegClass::Int);
+        #[cfg(target_arch = "x86_64")]
+        let reg = regalloc2::PReg::new(12, regalloc2::RegClass::Int);
+        #[cfg(target_arch = "aarch64")]
+        let reg_2 = regalloc2::PReg::new(20, regalloc2::RegClass::Int);
+        #[cfg(target_arch = "x86_64")]
+        let reg_2 = regalloc2::PReg::new(13, regalloc2::RegClass::Int);
+        let alloc = crate::regalloc_engine::AllocatedCfgProgram {
+            cfg_program: program.clone(),
+            functions: vec![crate::regalloc_engine::AllocatedCfgFunction {
+                lambda_id: crate::ir::LambdaId::new(0),
+                num_spillslots: 0,
+                edits: Vec::new(),
+                op_allocs: std::collections::HashMap::from([
+                    (op_id, vec![regalloc2::Allocation::reg(reg)]),
+                    (
+                        op_id_2,
+                        vec![
+                            regalloc2::Allocation::reg(reg),
+                            regalloc2::Allocation::reg(reg_2),
+                        ],
+                    ),
+                ]),
+                op_operands: std::collections::HashMap::from([
+                    (
+                        op_id,
+                        vec![(v0, crate::regalloc_engine::cfg_mir::OperandKind::Def)],
+                    ),
+                    (
+                        op_id_2,
+                        vec![
+                            (v0, crate::regalloc_engine::cfg_mir::OperandKind::Use),
+                            (
+                                crate::ir::VReg::new(1),
+                                crate::regalloc_engine::cfg_mir::OperandKind::Def,
+                            ),
+                        ],
+                    ),
+                ]),
+                edge_edits: Vec::new(),
+                return_result_allocs: Vec::new(),
+            }],
+        };
+        let backend_debug_info = crate::ir_backend::BackendDebugInfo {
+            op_infos: vec![
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id,
+                    line: 1,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 0,
+                        end_offset: 4,
+                    }],
+                },
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id: op_id_2,
+                    line: 2,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 4,
+                        end_offset: 8,
+                    }],
+                },
+                crate::ir_backend::BackendOpDebugInfo {
+                    lambda_id: 0,
+                    op_id: crate::regalloc_engine::cfg_mir::OpId::Term(term_id),
+                    line: 3,
+                    code_ranges: vec![crate::ir_backend::BackendCodeRange {
+                        start_offset: 8,
+                        end_offset: 12,
+                    }],
+                },
+            ],
+        };
+
+        let subprogram = cfg_mir_dwarf_variables(
+            &program,
+            &alloc,
+            Some(&backend_debug_info),
+            0x1000 as *const u8,
+            jit_dwarf_target_arch(),
+            true,
+        );
+
+        assert!(
+            !subprogram
+                .variables
+                .iter()
+                .any(|variable| variable.name == "v0")
+        );
+        assert_eq!(subprogram.lexical_blocks.len(), 1);
+        assert_eq!(subprogram.lexical_blocks[0].low_pc, 0x1000);
+        assert_eq!(subprogram.lexical_blocks[0].high_pc, 0x100c);
+        assert_eq!(subprogram.lexical_blocks[0].variables.len(), 1);
+        assert_eq!(subprogram.lexical_blocks[0].variables[0].name, "v0");
     }
 }

--- a/kajit/src/ir_backend.rs
+++ b/kajit/src/ir_backend.rs
@@ -1,11 +1,31 @@
 use crate::linearize::LinearIr;
 use crate::regalloc_engine::{AllocatedCfgProgram, cfg_mir};
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendCodeRange {
+    pub start_offset: u32,
+    pub end_offset: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackendOpDebugInfo {
+    pub lambda_id: u32,
+    pub op_id: cfg_mir::OpId,
+    pub line: u32,
+    pub code_ranges: Vec<BackendCodeRange>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct BackendDebugInfo {
+    pub op_infos: Vec<BackendOpDebugInfo>,
+}
+
 #[cfg(target_arch = "x86_64")]
 pub struct LinearBackendResult {
     pub buf: kajit_emit::x64::FinalizedEmission,
     pub entry: u32,
     pub source_map: Option<kajit_emit::SourceMap>,
+    pub backend_debug_info: Option<BackendDebugInfo>,
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -13,6 +33,7 @@ pub struct LinearBackendResult {
     pub buf: kajit_emit::aarch64::FinalizedEmission,
     pub entry: u32,
     pub source_map: Option<kajit_emit::SourceMap>,
+    pub backend_debug_info: Option<BackendDebugInfo>,
 }
 
 pub fn compile_linear_ir(ir: &LinearIr) -> LinearBackendResult {
@@ -53,5 +74,40 @@ pub fn compile_linear_ir_with_alloc_and_mode(
     {
         let _ = (ir, max_spillslots); // aarch64 backend reads from ra_mir directly
         crate::backends::aarch64::compile(cfg_program, alloc, apply_regalloc_edits)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ir::{IrBuilder, Width};
+    use facet::Facet;
+
+    #[test]
+    fn compile_linear_ir_records_backend_op_ranges() {
+        let mut builder = IrBuilder::new(<u32 as Facet>::SHAPE);
+        {
+            let mut rb = builder.root_region();
+            let value = rb.const_val(42);
+            rb.write_to_field(value, 0, Width::W4);
+            rb.set_results(&[]);
+        }
+        let mut func = builder.finish();
+        crate::ir_passes::run_default_passes(&mut func);
+        let linear = crate::linearize::linearize(&mut func);
+        let cfg_program = cfg_mir::lower_linear_ir(&linear);
+        let alloc = crate::regalloc_engine::allocate_cfg_program(&cfg_program)
+            .unwrap_or_else(|err| panic!("regalloc2 allocation failed in test: {err}"));
+
+        let result = compile_linear_ir_with_alloc_and_mode(&linear, &cfg_program, &alloc, true);
+        let backend_debug_info = result
+            .backend_debug_info
+            .expect("backend debug info should be present");
+        assert!(!backend_debug_info.op_infos.is_empty());
+        assert!(backend_debug_info.op_infos.iter().all(|op| {
+            op.code_ranges
+                .iter()
+                .all(|range| range.start_offset < range.end_offset)
+        }));
     }
 }

--- a/kajit/src/jit_dwarf.rs
+++ b/kajit/src/jit_dwarf.rs
@@ -1,8 +1,8 @@
 //! DWARF preparation utilities for JIT code.
 //!
-//! This module builds minimal DWARF v4 sections from a source map of
-//! `(code_offset, ra_mir_inst_index)` pairs: `.debug_line` for line tables,
-//! plus `.debug_info` and `.debug_abbrev` so that LLDB actually parses them.
+//! This module has two layers:
+//! - `JitDebugInfo`, a structured debug-info model owned by the compiler.
+//! - a DWARF v4 serializer that lowers that model to ELF sections.
 
 /// Owned DWARF sections ready to be attached to the JIT ELF.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -20,6 +20,12 @@ impl JitDwarfSections {
             && self.debug_info.is_empty()
             && self.debug_loc.is_empty()
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JitDebugLineRow {
+    pub code_offset: u32,
+    pub line: u32,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -41,10 +47,42 @@ pub struct DwarfVariable {
     pub location: DwarfVariableLocation,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JitDebugLexicalBlock {
+    pub low_pc: u64,
+    pub high_pc: u64,
+    pub variables: Vec<DwarfVariable>,
+    pub lexical_blocks: Vec<JitDebugLexicalBlock>,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DwarfTargetArch {
     X86_64,
     Aarch64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JitDebugLineTable {
+    pub file_name: String,
+    pub directory: Option<String>,
+    pub rows: Vec<JitDebugLineRow>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JitDebugSubprogram {
+    pub name: String,
+    pub frame_base_expression: Vec<u8>,
+    pub variables: Vec<DwarfVariable>,
+    pub lexical_blocks: Vec<JitDebugLexicalBlock>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct JitDebugInfo {
+    pub target_arch: DwarfTargetArch,
+    pub code_address: u64,
+    pub code_size: u64,
+    pub line_table: JitDebugLineTable,
+    pub subprogram: JitDebugSubprogram,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -84,6 +122,7 @@ const STANDARD_OPCODE_LENGTHS: [u8; 12] = [0, 1, 1, 1, 1, 0, 0, 0, 1, 0, 0, 1];
 
 const DW_TAG_COMPILE_UNIT: u8 = 0x11;
 const DW_TAG_BASE_TYPE: u8 = 0x24;
+const DW_TAG_LEXICAL_BLOCK: u8 = 0x0b;
 const DW_TAG_SUBPROGRAM: u8 = 0x2e;
 const DW_TAG_VARIABLE: u8 = 0x34;
 const DW_CHILDREN_YES: u8 = 0x01;
@@ -175,27 +214,60 @@ pub fn build_jit_dwarf_sections_with_variables(
         }
     }
 
-    let (debug_loc, variable_loc_offsets) = build_debug_loc_section(variables, code_address);
-    let frame_base_expr = expr_breg(frame_base_register(target_arch), 0);
+    let debug_info = JitDebugInfo {
+        target_arch,
+        code_address,
+        code_size,
+        line_table: JitDebugLineTable {
+            file_name: file_name.to_owned(),
+            directory: directory.map(ToOwned::to_owned),
+            rows: source_map
+                .iter()
+                .map(|(code_offset, ra_mir_inst_index)| JitDebugLineRow {
+                    code_offset: *code_offset,
+                    line: ra_mir_inst_index.saturating_add(1),
+                })
+                .collect(),
+        },
+        subprogram: JitDebugSubprogram {
+            name: subprogram_name.to_owned(),
+            frame_base_expression: expr_breg(frame_base_register(target_arch), 0),
+            variables: variables.to_vec(),
+            lexical_blocks: Vec::new(),
+        },
+    };
+    build_jit_dwarf_sections_from_debug_info(&debug_info)
+}
 
+pub fn build_jit_dwarf_sections_from_debug_info(
+    debug_info: &JitDebugInfo,
+) -> Result<JitDwarfSections, DwarfPrepError> {
+    if debug_info.line_table.file_name.as_bytes().contains(&0) {
+        return Err(DwarfPrepError::InteriorNul { field: "file_name" });
+    }
+    if let Some(dir) = &debug_info.line_table.directory
+        && dir.as_bytes().contains(&0)
+    {
+        return Err(DwarfPrepError::InteriorNul { field: "directory" });
+    }
+    if debug_info.subprogram.name.as_bytes().contains(&0) {
+        return Err(DwarfPrepError::InteriorNul {
+            field: "subprogram_name",
+        });
+    }
+    for variable in subprogram_variables_in_preorder(&debug_info.subprogram) {
+        if variable.name.as_bytes().contains(&0) {
+            return Err(DwarfPrepError::InteriorNul {
+                field: "variable_name",
+            });
+        }
+    }
+
+    let (debug_loc, variable_loc_offsets) = build_debug_loc_section_from_debug_info(debug_info);
     Ok(JitDwarfSections {
-        debug_line: build_debug_line_section(
-            code_address,
-            code_size,
-            source_map,
-            file_name,
-            directory,
-        )?,
+        debug_line: build_debug_line_section_from_debug_info(debug_info)?,
         debug_abbrev: build_debug_abbrev_section(),
-        debug_info: build_debug_info_section(
-            code_address,
-            code_size,
-            file_name,
-            subprogram_name,
-            &frame_base_expr,
-            variables,
-            &variable_loc_offsets,
-        ),
+        debug_info: build_debug_info_section_from_debug_info(debug_info, &variable_loc_offsets),
         debug_loc,
     })
 }
@@ -271,6 +343,17 @@ pub fn build_debug_abbrev_section() -> Vec<u8> {
     out.push(0);
     out.push(0);
 
+    // Abbrev 6: lexical block (has children: vars and nested lexical blocks).
+    push_uleb128(&mut out, 6);
+    out.push(DW_TAG_LEXICAL_BLOCK);
+    out.push(DW_CHILDREN_YES);
+    out.push(DW_AT_LOW_PC);
+    out.push(DW_FORM_ADDR);
+    out.push(DW_AT_HIGH_PC);
+    out.push(DW_FORM_DATA8);
+    out.push(0);
+    out.push(0);
+
     // End abbrev table.
     out.push(0);
     out
@@ -283,6 +366,7 @@ pub fn build_debug_info_section(
     subprogram_name: &str,
     frame_base_expr: &[u8],
     variables: &[DwarfVariable],
+    lexical_blocks: &[JitDebugLexicalBlock],
     variable_loc_offsets: &[u32],
 ) -> Vec<u8> {
     let mut die = Vec::new();
@@ -311,29 +395,16 @@ pub fn build_debug_info_section(
     push_uleb128(&mut die, frame_base_expr.len() as u64);
     die.extend_from_slice(frame_base_expr);
 
-    // Variable DIEs (abbrev 3) as children of subprogram.
+    // Variable DIEs and lexical blocks as children of subprogram.
     let mut next_loc_offset = 0usize;
-    for variable in variables {
-        match &variable.location {
-            DwarfVariableLocation::Expr(expr) => {
-                push_uleb128(&mut die, 4);
-                die.extend_from_slice(variable.name.as_bytes());
-                die.push(0);
-                push_uleb128(&mut die, expr.len() as u64);
-                die.extend_from_slice(expr);
-                die.extend_from_slice(&base_type_die_offset.to_le_bytes());
-            }
-            DwarfVariableLocation::List(_ranges) => {
-                let loc_offset = variable_loc_offsets[next_loc_offset];
-                next_loc_offset += 1;
-                push_uleb128(&mut die, 5);
-                die.extend_from_slice(variable.name.as_bytes());
-                die.push(0);
-                die.extend_from_slice(&loc_offset.to_le_bytes());
-                die.extend_from_slice(&base_type_die_offset.to_le_bytes());
-            }
-        }
-    }
+    emit_variable_dies(
+        &mut die,
+        variables,
+        lexical_blocks,
+        variable_loc_offsets,
+        &mut next_loc_offset,
+        base_type_die_offset,
+    );
 
     // End of subprogram children, then end of CU children.
     die.push(0);
@@ -349,13 +420,120 @@ pub fn build_debug_info_section(
     section
 }
 
+fn emit_variable_dies(
+    die: &mut Vec<u8>,
+    variables: &[DwarfVariable],
+    lexical_blocks: &[JitDebugLexicalBlock],
+    variable_loc_offsets: &[u32],
+    next_loc_offset: &mut usize,
+    base_type_die_offset: u32,
+) {
+    for variable in variables {
+        match &variable.location {
+            DwarfVariableLocation::Expr(expr) => {
+                push_uleb128(die, 4);
+                die.extend_from_slice(variable.name.as_bytes());
+                die.push(0);
+                push_uleb128(die, expr.len() as u64);
+                die.extend_from_slice(expr);
+                die.extend_from_slice(&base_type_die_offset.to_le_bytes());
+            }
+            DwarfVariableLocation::List(_ranges) => {
+                let loc_offset = variable_loc_offsets[*next_loc_offset];
+                *next_loc_offset += 1;
+                push_uleb128(die, 5);
+                die.extend_from_slice(variable.name.as_bytes());
+                die.push(0);
+                die.extend_from_slice(&loc_offset.to_le_bytes());
+                die.extend_from_slice(&base_type_die_offset.to_le_bytes());
+            }
+        }
+    }
+    for lexical_block in lexical_blocks {
+        emit_lexical_block_die(
+            die,
+            lexical_block,
+            variable_loc_offsets,
+            next_loc_offset,
+            base_type_die_offset,
+        );
+    }
+}
+
+fn emit_lexical_block_die(
+    die: &mut Vec<u8>,
+    lexical_block: &JitDebugLexicalBlock,
+    variable_loc_offsets: &[u32],
+    next_loc_offset: &mut usize,
+    base_type_die_offset: u32,
+) {
+    push_uleb128(die, 6);
+    die.extend_from_slice(&lexical_block.low_pc.to_le_bytes());
+    die.extend_from_slice(
+        &lexical_block
+            .high_pc
+            .saturating_sub(lexical_block.low_pc)
+            .to_le_bytes(),
+    );
+    emit_variable_dies(
+        die,
+        &lexical_block.variables,
+        &lexical_block.lexical_blocks,
+        variable_loc_offsets,
+        next_loc_offset,
+        base_type_die_offset,
+    );
+    die.push(0);
+}
+
+fn variables_in_preorder<'a>(
+    variables: &'a [DwarfVariable],
+    lexical_blocks: &'a [JitDebugLexicalBlock],
+) -> Vec<&'a DwarfVariable> {
+    let mut out = Vec::new();
+    collect_variables_in_preorder(variables, lexical_blocks, &mut out);
+    out
+}
+
+fn collect_variables_in_preorder<'a>(
+    variables: &'a [DwarfVariable],
+    lexical_blocks: &'a [JitDebugLexicalBlock],
+    out: &mut Vec<&'a DwarfVariable>,
+) {
+    out.extend(variables.iter());
+    for lexical_block in lexical_blocks {
+        collect_variables_in_preorder(&lexical_block.variables, &lexical_block.lexical_blocks, out);
+    }
+}
+
+fn subprogram_variables_in_preorder(subprogram: &JitDebugSubprogram) -> Vec<&DwarfVariable> {
+    variables_in_preorder(&subprogram.variables, &subprogram.lexical_blocks)
+}
+
+pub fn build_debug_info_section_from_debug_info(
+    debug_info: &JitDebugInfo,
+    variable_loc_offsets: &[u32],
+) -> Vec<u8> {
+    build_debug_info_section(
+        debug_info.code_address,
+        debug_info.code_size,
+        &debug_info.line_table.file_name,
+        &debug_info.subprogram.name,
+        &debug_info.subprogram.frame_base_expression,
+        &debug_info.subprogram.variables,
+        &debug_info.subprogram.lexical_blocks,
+        variable_loc_offsets,
+    )
+}
+
 pub fn build_debug_loc_section(
     variables: &[DwarfVariable],
+    lexical_blocks: &[JitDebugLexicalBlock],
     code_address: u64,
 ) -> (Vec<u8>, Vec<u32>) {
     let mut section = Vec::<u8>::new();
     let mut offsets = Vec::<u32>::new();
-    for variable in variables {
+    for variable in variables_in_preorder(variables, lexical_blocks) {
         if let DwarfVariableLocation::List(locations) = &variable.location {
             offsets.push(section.len() as u32);
             for loc in locations {
@@ -375,6 +553,14 @@ pub fn build_debug_loc_section(
         }
     }
     (section, offsets)
+}
+
+pub fn build_debug_loc_section_from_debug_info(debug_info: &JitDebugInfo) -> (Vec<u8>, Vec<u32>) {
+    build_debug_loc_section(
+        &debug_info.subprogram.variables,
+        &debug_info.subprogram.lexical_blocks,
+        debug_info.code_address,
+    )
 }
 
 pub fn dwarf_register_from_hw_encoding(target_arch: DwarfTargetArch, hw_enc: u8) -> Option<u16> {
@@ -548,6 +734,24 @@ pub fn build_debug_line_section(
     section.extend_from_slice(&program);
     section.shrink_to_fit();
     Ok(section)
+}
+
+pub fn build_debug_line_section_from_debug_info(
+    debug_info: &JitDebugInfo,
+) -> Result<Vec<u8>, DwarfPrepError> {
+    let rows = debug_info
+        .line_table
+        .rows
+        .iter()
+        .map(|row| (row.code_offset, row.line.saturating_sub(1)))
+        .collect::<Vec<_>>();
+    build_debug_line_section(
+        debug_info.code_address,
+        debug_info.code_size,
+        &rows,
+        &debug_info.line_table.file_name,
+        debug_info.line_table.directory.as_deref(),
+    )
 }
 
 fn push_uleb128(out: &mut Vec<u8>, mut value: u64) {
@@ -726,6 +930,7 @@ mod tests {
         let abbrev = build_debug_abbrev_section();
         assert_eq!(abbrev[0], 0x01); // CU abbrev code
         assert!(abbrev.contains(&DW_TAG_COMPILE_UNIT));
+        assert!(abbrev.contains(&DW_TAG_LEXICAL_BLOCK));
         assert!(abbrev.contains(&DW_TAG_SUBPROGRAM));
         assert!(abbrev.contains(&DW_TAG_VARIABLE));
         assert_eq!(abbrev.last().copied(), Some(0));
@@ -744,6 +949,7 @@ mod tests {
             "kajit::decode::Example",
             &expr_reg(frame_base_register(DwarfTargetArch::X86_64)),
             &variables,
+            &[],
             &[0],
         );
 
@@ -834,7 +1040,7 @@ mod tests {
             },
         ];
 
-        let (loc, offsets) = build_debug_loc_section(&vars, 0);
+        let (loc, offsets) = build_debug_loc_section(&vars, &[], 0);
         assert_eq!(offsets.len(), 1);
         assert_eq!(offsets[0], 0);
         assert!(!loc.is_empty());
@@ -856,12 +1062,36 @@ mod tests {
             }]),
         }];
 
-        let (loc, offsets) = build_debug_loc_section(&vars, 0x1000);
+        let (loc, offsets) = build_debug_loc_section(&vars, &[], 0x1000);
         assert_eq!(offsets, vec![0]);
         let start = u64::from_le_bytes(loc[0..8].try_into().unwrap());
         let end = u64::from_le_bytes(loc[8..16].try_into().unwrap());
         assert_eq!(start, 0x10);
         assert_eq!(end, 0x20);
+    }
+
+    #[test]
+    fn debug_loc_collects_lexical_block_variables() {
+        let lexical_blocks = vec![JitDebugLexicalBlock {
+            low_pc: 0x1000,
+            high_pc: 0x1010,
+            variables: vec![DwarfVariable {
+                name: "scoped".to_string(),
+                location: DwarfVariableLocation::List(vec![DwarfLocationRange {
+                    start: 0x1004,
+                    end: 0x1008,
+                    expression: expr_reg(9),
+                }]),
+            }],
+            lexical_blocks: Vec::new(),
+        }];
+
+        let (loc, offsets) = build_debug_loc_section(&[], &lexical_blocks, 0x1000);
+        assert_eq!(offsets, vec![0]);
+        let start = u64::from_le_bytes(loc[0..8].try_into().unwrap());
+        let end = u64::from_le_bytes(loc[8..16].try_into().unwrap());
+        assert_eq!(start, 0x4);
+        assert_eq!(end, 0x8);
     }
 
     #[test]
@@ -923,5 +1153,50 @@ mod tests {
         )
         .unwrap();
         assert!(!sections.debug_loc.is_empty());
+    }
+
+    #[test]
+    fn build_jit_dwarf_sections_from_debug_info_populates_all_sections() {
+        let debug_info = JitDebugInfo {
+            target_arch: DwarfTargetArch::X86_64,
+            code_address: 0x1000,
+            code_size: 8,
+            line_table: JitDebugLineTable {
+                file_name: "decoder.ra".to_string(),
+                directory: Some("jit".to_string()),
+                rows: vec![JitDebugLineRow {
+                    code_offset: 0,
+                    line: 1,
+                }],
+            },
+            subprogram: JitDebugSubprogram {
+                name: "kajit::decode::Bools".to_string(),
+                frame_base_expression: expr_breg(frame_base_register(DwarfTargetArch::X86_64), 0),
+                variables: vec![DwarfVariable {
+                    name: "flag".to_string(),
+                    location: DwarfVariableLocation::Expr(expr_reg(0)),
+                }],
+                lexical_blocks: vec![JitDebugLexicalBlock {
+                    low_pc: 0x1000,
+                    high_pc: 0x1008,
+                    variables: vec![DwarfVariable {
+                        name: "v0".to_string(),
+                        location: DwarfVariableLocation::List(vec![DwarfLocationRange {
+                            start: 0x1004,
+                            end: 0x1008,
+                            expression: expr_reg(1),
+                        }]),
+                    }],
+                    lexical_blocks: Vec::new(),
+                }],
+            },
+        };
+
+        let sections = build_jit_dwarf_sections_from_debug_info(&debug_info).unwrap();
+        assert!(!sections.debug_line.is_empty());
+        assert!(!sections.debug_abbrev.is_empty());
+        assert!(!sections.debug_info.is_empty());
+        assert!(!sections.debug_loc.is_empty());
+        assert!(!sections.is_empty());
     }
 }

--- a/scripts/kajit_lldb_side_by_side.py
+++ b/scripts/kajit_lldb_side_by_side.py
@@ -58,6 +58,72 @@ def _current_line(debugger):
     return line if line > 0 else None
 
 
+def _current_frame(debugger):
+    target = debugger.GetSelectedTarget()
+    process = target.GetProcess()
+    if not process.IsValid():
+        return None
+    thread = process.GetSelectedThread()
+    if not thread.IsValid():
+        return None
+    frame = thread.GetSelectedFrame()
+    if not frame.IsValid():
+        return None
+    return frame
+
+
+def _variable_state(debugger, name):
+    frame = _current_frame(debugger)
+    if frame is None:
+        return "missing-frame", None
+    value = frame.FindVariable(name)
+    if value is None or not value.IsValid():
+        return "missing", None
+    if hasattr(value, "IsInScope") and not value.IsInScope():
+        return "unavailable", None
+    rendered = value.GetValue()
+    if rendered is None:
+        rendered = value.GetSummary()
+    if rendered is None and value.GetNumChildren() == 0:
+        return "unavailable", None
+    return "available", rendered
+
+
+def _listed_variable_names(debugger):
+    frame = _current_frame(debugger)
+    if frame is None:
+        return None, "missing-frame"
+    values = frame.GetVariables(False, True, False, True)
+    names = []
+    for index in range(values.GetSize()):
+        value = values.GetValueAtIndex(index)
+        if value is None or not value.IsValid():
+            continue
+        name = value.GetName()
+        if name:
+            names.append(name)
+    return names, None
+
+
+def _step_to_line(debugger, target_line):
+    current = _current_line(debugger)
+    if current is None:
+        return None, "no source line is selected"
+    if current > target_line:
+        return current, f"current line {current} is already past requested line {target_line}"
+    for _ in range(256):
+        current = _current_line(debugger)
+        if current == target_line:
+            return current, None
+        if current is not None and current > target_line:
+            return current, f"stepped past requested line {target_line}, now at {current}"
+        debugger.HandleCommand("thread step-over")
+        current = _current_line(debugger)
+        if current == target_line:
+            return current, None
+    return _current_line(debugger), f"did not reach line {target_line} within step budget"
+
+
 def _evaluate_u64(debugger, expr_text):
     target = debugger.GetSelectedTarget()
     process = target.GetProcess()
@@ -158,6 +224,10 @@ def kajit_help(_debugger, _command, result, _internal_dict):
         "kajit-bytes [count] - read bytes at input_ptr as hex + ASCII (default: 16)",
         "kajit-text [count]  - read bytes at input_ptr as printable text (default: 32)",
         "kajit-break [regex] - set a JIT-code breakpoint (default regex: kajit::decode::)",
+        "kajit-step-to <line> - step over until the current CFG-MIR line matches",
+        "kajit-var-state <var> - print whether one variable is available in the current frame",
+        "kajit-listed-vars - print local variable names visible in the current lexical scope",
+        "kajit-expect <line> <var> <available|unavailable|listed|unlisted> - step, check, and print OK/FAIL",
         "kajit-here [line]  - show interpreter reference for current or explicit CFG-MIR line",
         "kajit-list [line]  - list available reference lines or dump one explicit line",
         "kajit-step         - thread step-over, then print interpreter reference for the new line",
@@ -173,6 +243,78 @@ def kajit_break(debugger, command, result, _internal_dict):
     escaped = pattern.replace("\\", "\\\\").replace('"', '\\"')
     debugger.HandleCommand(f'breakpoint set -r "{escaped}"')
     result.PutCString(f"set JIT breakpoint regex: {pattern}")
+
+
+def kajit_step_to(debugger, command, result, _internal_dict):
+    raw = command.strip()
+    if not raw:
+        result.PutCString("usage: kajit-step-to <line>")
+        return
+    target_line = int(raw)
+    line, err = _step_to_line(debugger, target_line)
+    if err is not None:
+        result.PutCString(f"FAIL line={target_line} error={err}")
+        return
+    result.PutCString(f"OK line={line}")
+
+
+def kajit_var_state(debugger, command, result, _internal_dict):
+    name = command.strip()
+    if not name:
+        result.PutCString("usage: kajit-var-state <var>")
+        return
+    state, rendered = _variable_state(debugger, name)
+    line = _current_line(debugger)
+    if rendered is None:
+        result.PutCString(f"VAR line={line} name={name} state={state}")
+    else:
+        result.PutCString(f"VAR line={line} name={name} state={state} value={rendered}")
+
+
+def kajit_listed_vars(debugger, _command, result, _internal_dict):
+    names, err = _listed_variable_names(debugger)
+    if err is not None:
+        result.PutCString(f"FAIL error={err}")
+        return
+    line = _current_line(debugger)
+    result.PutCString(f"LISTED line={line} names={' '.join(names)}")
+
+
+def kajit_expect(debugger, command, result, _internal_dict):
+    parts = command.strip().split()
+    if len(parts) != 3:
+        result.PutCString("usage: kajit-expect <line> <var> <available|unavailable|listed|unlisted>")
+        return
+    target_line = int(parts[0])
+    name = parts[1]
+    expected = parts[2]
+    line, err = _step_to_line(debugger, target_line)
+    if err is not None:
+        result.PutCString(f"FAIL line={target_line} name={name} error={err}")
+        return
+    if expected in ("listed", "unlisted"):
+        names, list_err = _listed_variable_names(debugger)
+        if list_err is not None:
+            result.PutCString(f"FAIL line={line} name={name} error={list_err}")
+            return
+        actual = "listed" if name in names else "unlisted"
+        rendered = None
+    else:
+        actual, rendered = _variable_state(debugger, name)
+    if actual == expected:
+        if rendered is None:
+            result.PutCString(f"OK line={line} name={name} state={actual}")
+        else:
+            result.PutCString(f"OK line={line} name={name} state={actual} value={rendered}")
+        return
+    if rendered is None:
+        result.PutCString(
+            f"FAIL line={line} name={name} expected={expected} actual={actual}"
+        )
+    else:
+        result.PutCString(
+            f"FAIL line={line} name={name} expected={expected} actual={actual} value={rendered}"
+        )
 
 
 def kajit_bytes(debugger, command, result, _internal_dict):
@@ -254,6 +396,18 @@ def __lldb_init_module(debugger, _internal_dict):
     )
     debugger.HandleCommand(
         "command script add -f kajit_lldb_side_by_side.kajit_break kajit-break"
+    )
+    debugger.HandleCommand(
+        "command script add -f kajit_lldb_side_by_side.kajit_step_to kajit-step-to"
+    )
+    debugger.HandleCommand(
+        "command script add -f kajit_lldb_side_by_side.kajit_var_state kajit-var-state"
+    )
+    debugger.HandleCommand(
+        "command script add -f kajit_lldb_side_by_side.kajit_listed_vars kajit-listed-vars"
+    )
+    debugger.HandleCommand(
+        "command script add -f kajit_lldb_side_by_side.kajit_expect kajit-expect"
     )
     debugger.HandleCommand(
         "command script add -f kajit_lldb_side_by_side.kajit_here kajit-here"

--- a/scripts/lldb-check-vars.sh
+++ b/scripts/lldb-check-vars.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <test_name> <line:var:available|unavailable|listed|unlisted>..."
+  echo "example: $0 json::bool_true_false 4:v46:unavailable 5:v46:available 5:v47:unlisted"
+  exit 1
+fi
+
+filter="$1"
+shift
+expectations=("$@")
+export KAJIT_DEBUG=1
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+break_regex="${KAJIT_LLDB_BREAK_REGEX:-kajit::decode::}"
+
+mktemp_portable() {
+  local prefix="$1"
+  mktemp -t "${prefix}.XXXXXX"
+}
+
+json_output="$(cargo nextest list -p kajit -E "test(=$filter)" --message-format json)"
+
+match_json=""
+if match_json="$(python3 -c '
+import json
+import sys
+
+matches = []
+for raw in sys.stdin:
+    raw = raw.strip()
+    if not raw.startswith("{"):
+        continue
+    try:
+        msg = json.loads(raw)
+    except json.JSONDecodeError:
+        continue
+    suites = msg.get("rust-suites")
+    if not isinstance(suites, dict):
+        continue
+    for suite in suites.values():
+        bin_path = suite.get("binary-path")
+        testcases = suite.get("testcases", {})
+        if not isinstance(testcases, dict):
+            continue
+        for test_name, testcase in testcases.items():
+            fm = testcase.get("filter-match", {})
+            if isinstance(fm, dict) and fm.get("status") == "matches":
+                matches.append((bin_path, test_name))
+
+if not matches:
+    sys.exit(2)
+
+uniq = []
+seen = set()
+for pair in matches:
+    if pair in seen:
+        continue
+    seen.add(pair)
+    uniq.append(pair)
+
+if len(uniq) != 1:
+    print(json.dumps({"error": "ambiguous", "matches": uniq}))
+    sys.exit(3)
+
+bin_path, test_name = uniq[0]
+print(json.dumps({"binary_path": bin_path, "test_name": test_name}))
+')"; then
+  :
+else
+  status=$?
+  if [[ $status -eq 2 ]]; then
+    echo "no matching test found for filter: $filter"
+  elif [[ $status -eq 3 ]]; then
+    echo "filter matched more than one test; use a more specific name: $filter"
+  else
+    echo "failed to resolve a unique test for filter: $filter"
+  fi
+  exit 1
+fi <<<"$json_output"
+
+binary_path="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["binary_path"])' <<<"$match_json")"
+test_name="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["test_name"])' <<<"$match_json")"
+
+cfg_mir_tmp="$(mktemp_portable kajit-lldb-cfg)"
+ref_tmp="$(mktemp_portable kajit-lldb-ref)"
+output_tmp="$(mktemp_portable kajit-lldb-out)"
+cleanup() {
+  rm -f "$cfg_mir_tmp" "$ref_tmp" "$output_tmp"
+}
+trap cleanup EXIT
+
+if cargo run -q --manifest-path "$repo_root/xtask/Cargo.toml" -- corpus-cfg-mir "$filter" >"$cfg_mir_tmp" 2>/dev/null; then
+  if cargo run -q --manifest-path "$repo_root/xtask/Cargo.toml" -- \
+    debug-cfg-mir lldb-ref "$cfg_mir_tmp" --corpus-test "$filter" >"$ref_tmp" 2>/dev/null; then
+    export KAJIT_LLDB_REF_FILE="$ref_tmp"
+  fi
+fi
+
+lldb_args=(
+  --batch
+  -o "settings set plugin.jit-loader.gdb.enable on"
+  -o "command script import $repo_root/scripts/kajit_lldb_side_by_side.py"
+  -o "breakpoint set -n __jit_debug_register_code"
+  -o "run"
+  -o "kajit-break $break_regex"
+  -o "continue"
+)
+
+for spec in "${expectations[@]}"; do
+  IFS=: read -r line var state extra <<<"$spec"
+  if [[ -n "${extra:-}" || -z "${line:-}" || -z "${var:-}" || -z "${state:-}" ]]; then
+    echo "invalid expectation '$spec' (expected line:var:available|unavailable|listed|unlisted)"
+    exit 1
+  fi
+  if [[ "$state" != "available" && "$state" != "unavailable" && "$state" != "listed" && "$state" != "unlisted" ]]; then
+    echo "invalid state '$state' in expectation '$spec'"
+    exit 1
+  fi
+  lldb_args+=(-o "kajit-expect $line $var $state")
+done
+
+echo "KAJIT_DEBUG=1"
+echo "binary: $binary_path"
+echo "test:   $test_name"
+echo "regex:  $break_regex"
+printf 'check:  %s\n' "${expectations[@]}"
+
+set +e
+lldb "${lldb_args[@]}" -- "$binary_path" --exact "$test_name" --nocapture >"$output_tmp" 2>&1
+lldb_status=$?
+set -e
+
+cat "$output_tmp"
+
+if [[ $lldb_status -ne 0 ]]; then
+  echo "lldb exited with status $lldb_status"
+  exit "$lldb_status"
+fi
+
+fail_count="$(grep -c '^FAIL ' "$output_tmp" || true)"
+ok_count="$(grep -c '^OK line=' "$output_tmp" || true)"
+expected_count="${#expectations[@]}"
+
+if [[ "$fail_count" -ne 0 ]]; then
+  echo "scripted LLDB checks failed"
+  exit 1
+fi
+
+if [[ "$ok_count" -ne "$expected_count" ]]; then
+  echo "scripted LLDB checks were incomplete: expected $expected_count OK lines, saw $ok_count"
+  exit 1
+fi
+
+echo "scripted LLDB checks passed"


### PR DESCRIPTION
## Summary

Improve Kajit's JIT DWARF pipeline by introducing a structured debug info model, backend-emitted op/code ranges, and lexical blocks synthesized from CFG-MIR/debug metadata instead of a flat subprogram-only local list.

## Changes

- add a structured JIT debug info model in `jit_dwarf.rs`
- record per-op emitted code ranges in both backends and plumb them through `LinearBackendResult`
- build CFG variable location lists from backend op ranges instead of reconstructing them from line rows
- tighten value availability so defs become visible only after their defining op completes
- synthesize coarse lexical blocks and emit `DW_TAG_lexical_block` DIEs in the DWARF v4 writer
- add scripted LLDB helpers and `scripts/lldb-check-vars.sh` for availability and visibility checks
- document the LLDB workflow and ignore generated `scripts/__pycache__/`

## Verification

- `cargo nextest run -p kajit -E 'test(builds_dwarf_sections_from_source_map_lines) | test(deser_dwarf_variables_cover_fixed_runtime_state) | test(cfg_value_dwarf_variables_cover_def_vregs) | test(cfg_value_dwarf_variables_keep_edge_carried_defs_live) | test(cfg_mir_dwarf_variables_place_block_local_vregs_in_lexical_blocks) | test(build_jit_dwarf_sections_from_debug_info_populates_all_sections) | test(build_jit_dwarf_sections_populates_all_sections) | test(build_jit_dwarf_sections_uses_debug_loc_for_ranged_variables) | test(debug_abbrev_contains_cu_subprogram_variable_abbrevs) | test(debug_line_rows_match_source_map) | test(debug_info_contains_cu_subprogram_and_variables) | test(debug_loc_builds_per_variable_lists_with_terminators) | test(debug_loc_collects_lexical_block_variables) | test(debug_loc_encodes_ranges_relative_to_cu_low_pc)'`
- `bash scripts/lldb-check-vars.sh json::bool_true_false 4:v46:unavailable 5:v46:available 5:v46:listed 5:v47:unlisted`
- push checks passed (`build tests`, `run tests`)

## Follow-up

The larger "carry debug scope provenance through RVSDG and lowering" design is tracked separately in:

- #187
- #188
- #189
- #190
- #191
- #192
